### PR TITLE
Switch from Py_eval_input to Py_single_input

### DIFF
--- a/python.cpp
+++ b/python.cpp
@@ -411,7 +411,7 @@ static void PythonEvalOrExec(
   // Compile as an expression
   PYW_GIL_CHECK_LOCKED_SCOPE();
   PyCompilerFlags cf = {0};
-  newref_t py_code(Py_CompileStringFlags(str, filename, Py_eval_input, &cf));
+  newref_t py_code(Py_CompileStringFlags(str, filename, Py_single_input, &cf));
   if ( py_code == NULL || PyErr_Occurred() )
   {
     // Not an expression?


### PR DESCRIPTION
Hello,

This is a little change which should open the possibility of improving the repl a bit. While the commit messages explain it in more detail, this change allows you to use Python's `sys.displayhook` with IDApy. Please note that this does not change output formatting by default, it just allows the user to do so. It also has no affect on integer input or parsing. Additionally, this allows `_` to be used as a special variable containing the result of the previous expression:

I've tested this on some IDBs and it seems to work. On the other hand this is the first time I've spent any time inside the python interpreter, so if this catastrophically breaks things I'm very sorry. The only thing I'm aware would change is pasting multi-line code fragments into the repl which this change breaks. I don't know if there are ways around this?

Finally, if this is something you're interested in I'm happy to write some tests, however I wanted a bit more information before doing so -- I think this will change the way code is evaluated in the repl vs via Alt+F7, meaning the way the test is invoked would be important. The easiest way is just to try to use `_` from the repl, but I could also write a display hook which just sets a global and use that to test.