### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/Scripts/3rd/BboeVt.py
+++ b/Scripts/3rd/BboeVt.py
@@ -4,6 +4,7 @@ Original code by Bryce Boe: http://www.bryceboe.com/2010/09/01/submitting-binari
 Modified by Elias Bachaalany <elias at hex-rays.com>
 
 """
+from __future__ import print_function
 
 import hashlib, httplib, mimetypes, os, pprint, simplejson, sys, urlparse
 

--- a/Scripts/AsmViewer.py
+++ b/Scripts/AsmViewer.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # -----------------------------------------------------------------------
 # This is an example illustrating how to use customview in Python
 # The sample will allow you to open an assembly file and display it in color
@@ -192,9 +193,9 @@ class asmview_t(ida_kernwin.simplecustviewer_t, asm_colorizer_t):
             self.ClearLines()
             self.Refresh()
         elif vkey == ord('S'):
-            print "Selection (x1, y1, x2, y2) = ", self.GetSelection()
+            print("Selection (x1, y1, x2, y2) = ", self.GetSelection())
         elif vkey == ord('I'):
-            print "Position (line, x, y) = ", self.GetPos(mouse = 0)
+            print("Position (line, x, y) = ", self.GetPos(mouse = 0))
         else:
             return False
         return True

--- a/Scripts/CallStackWalk.py
+++ b/Scripts/CallStackWalk.py
@@ -107,7 +107,7 @@ def CallStackWalk(nn):
     sp = idautils.cpu.Esp - word_size
     while sp < stack_seg.end_ea:
         sp += word_size
-        ptr = idautils.GetDataList(sp, 1, word_size).next()
+        ptr = next(idautils.GetDataList(sp, 1, word_size))
         seg = ida_segment.getseg(ptr)
         # only accept executable segments
         if (not seg) or ((seg.perm & ida_segment.SEGPERM_EXEC) == 0):

--- a/Scripts/DbgCmd.py
+++ b/Scripts/DbgCmd.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # -----------------------------------------------------------------------
 # Debugger command prompt with CustomViewers
 # (c) Hex-Rays
@@ -96,7 +97,7 @@ class dbgcmd_t(ida_kernwin.simplecustviewer_t):
 def show_win():
     x = dbgcmd_t()
     if not x.Create():
-        print "Failed to create debugger command line!"
+        print("Failed to create debugger command line!")
         return None
     x.Show()
 

--- a/Scripts/DrvsDispatch.py
+++ b/Scripts/DrvsDispatch.py
@@ -6,6 +6,7 @@ Copyright (c) 1990-2018 Hex-Rays
 ALL RIGHTS RESERVED.
 
 """
+from __future__ import print_function
 
 import re
 
@@ -54,7 +55,7 @@ def GetDriverDispatch():
 
     # force reloading of module symbols
     if not CmdReloadForce():
-        print "Could not communicate with WinDbg, make sure the debugger is running!"
+        print("Could not communicate with WinDbg, make sure the debugger is running!")
         return None
 
     # get driver list
@@ -75,7 +76,7 @@ def GetDriverDispatch():
       tbl_out = CmdDrvObj(drvname)
 
       if not tbl_out:
-          print "Failed to get driver object for", drvname
+          print("Failed to get driver object for", drvname)
           continue
 
       # for each line
@@ -116,4 +117,4 @@ if r:
     c = DispatchChoose("Dispatch table browser", r)
     c.Show(True)
 else:
-    print "Failed to retrieve dispatchers list!"
+    print("Failed to retrieve dispatchers list!")

--- a/Scripts/ExchainDump.py
+++ b/Scripts/ExchainDump.py
@@ -6,6 +6,7 @@ Copyright (c) 1990-2009 Hex-Rays
 ALL RIGHTS RESERVED.
 
 """
+from __future__ import print_function
 
 import re
 
@@ -51,4 +52,4 @@ def main():
 
 ok, r = main()
 if not ok:
-    print r
+    print(r)

--- a/Scripts/FindInstructions.py
+++ b/Scripts/FindInstructions.py
@@ -16,6 +16,7 @@ The general syntax is:
 Copyright (c) 1990-2018 Hex-Rays
 ALL RIGHTS RESERVED.
 """
+from __future__ import print_function
 import re
 
 import ida_idaapi
@@ -73,7 +74,7 @@ def FindInstructions(instr, asm_where=None):
     bin_str = ' '.join(["%02X" % ord(x) for x in buf])
 
     # find all binary strings
-    print "Searching for: [%s]" % bin_str
+    print("Searching for: [%s]" % bin_str)
     ea = ida_ida.cvar.inf.min_ea
     ret = []
     while True:
@@ -154,7 +155,7 @@ def find(s=None, x=False, asm_where=None):
         c = SearchResultChoose(title, results)
         c.Show(True)
     else:
-        print ret
+        print(ret)
 
 # -----------------------------------------------------------------------
-print "Please use find('asm_stmt1;xx yy;...', x=Bool,asm_where=ea) to search for instructions or opcodes. Specify x=true to filter out non-executable segments"
+print("Please use find('asm_stmt1;xx yy;...', x=Bool,asm_where=ea) to search for instructions or opcodes. Specify x=true to filter out non-executable segments")

--- a/Scripts/ImpRef.py
+++ b/Scripts/ImpRef.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # -----------------------------------------------------------------------
 # This is an example illustrating how to enumerate all addresses
 # that refer to all imported functions in a given module
@@ -47,7 +48,7 @@ def find_import_ref(dllname):
                 continue
 
             # save results
-            if not R.has_key(i):
+            if i not in R:
                 R[i] = []
 
             R[i].append(ea)

--- a/Scripts/ImportExportViewer.py
+++ b/Scripts/ImportExportViewer.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # -----------------------------------------------------------------------
 # This is an example illustrating how to:
 # - enumerate imports
@@ -100,7 +101,7 @@ class ImpExpForm_t(PluginForm):
         """
         global ImpExpForm
         del ImpExpForm
-        print "Closed"
+        print("Closed")
 
 
     def Show(self):

--- a/Scripts/PteDump.py
+++ b/Scripts/PteDump.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 import ida_kernwin
 import ida_segment

--- a/Scripts/SEHGraph.py
+++ b/Scripts/SEHGraph.py
@@ -7,6 +7,7 @@ It will be easy to see what thread uses what handler and what handlers are commo
 Copyright (c) 1990-2018 Hex-Rays
 ALL RIGHTS RESERVED.
 """
+from __future__ import print_function
 
 import ida_kernwin
 import ida_graph
@@ -88,7 +89,7 @@ class SEHGraph(ida_graph.GraphViewer):
 
               # Get the node id given the handler address
               # We use an addr -> id dictionary so that similar addresses get similar node id
-              if not addr_id.has_key(handler):
+              if handler not in addr_id:
                   id = self.AddNode( (False, handler, s) )
                   addr_id[handler] = id # add this ID
               else:
@@ -113,12 +114,12 @@ class SEHGraph(ida_graph.GraphViewer):
             self.Show()
             s = "SEH chain for " + hex(value)
             t = "-" * len(s)
-            print t
-            print s
-            print t
+            print(t)
+            print(s)
+            print(t)
             for handler in self.result[value]:
-                print "%x: %s" % (handler, self.names[handler])
-            print t
+                print("%x: %s" % (handler, self.names[handler]))
+            print(t)
         else:
             ida_kernwin.jumpto(value)
         return True
@@ -127,7 +128,7 @@ class SEHGraph(ida_graph.GraphViewer):
 # -----------------------------------------------------------------------
 def main():
     if not ida_idd.dbg_can_query():
-        print "The debugger must be active and suspended before using this script!"
+        print("The debugger must be active and suspended before using this script!")
         return
 
     # Save current thread id

--- a/Scripts/VaDump.py
+++ b/Scripts/VaDump.py
@@ -6,6 +6,7 @@ Copyright (c) 1990-2009 Hex-Rays
 ALL RIGHTS RESERVED.
 
 """
+from __future__ import print_function
 
 import re
 
@@ -81,4 +82,4 @@ def main():
     return (True, "Success!")
 r = main()
 if not r[0]:
-    print r[1]
+    print(r[1])

--- a/Scripts/VirusTotal.py
+++ b/Scripts/VirusTotal.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # -----------------------------------------------------------------------
 # VirusTotal IDA Plugin
 # By Elias Bachaalany <elias at hex-rays.com>

--- a/Scripts/callstack_test.py
+++ b/Scripts/callstack_test.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 import os
 
@@ -8,7 +9,7 @@ def __sys(cmd, fmt=None, echo=True):
     r = []
     for cmd in [x for x in (cmd % fmt).split("\n") if len(x)]:
         if echo:
-            print ">>>", cmd
+            print(">>>", cmd)
         r.append((os.system(cmd), cmd))
     return r
 
@@ -48,12 +49,12 @@ void func%(n)d()
 """
 
 if len(sys.argv) < 2:
-    print "usage: gen nb_calls pause_frequency"
+    print("usage: gen nb_calls pause_frequency")
     sys.exit(0)
 
 n = int(sys.argv[1])
 if n < 1:
-    print "at least one call should be passed!"
+    print("at least one call should be passed!")
     sys.exit(1)
 
 m = int(sys.argv[2])

--- a/Scripts/msdnapihelp.py
+++ b/Scripts/msdnapihelp.py
@@ -6,6 +6,7 @@ and returns the results in a new web browser page.
 
 This script depends on the feedparser package: http://code.google.com/p/feedparser/
 """
+from __future__ import print_function
 
 # -----------------------------------------------------------------------
 import ida_kernwin
@@ -57,11 +58,11 @@ class msdnapihelp_plugin_t(ida_idaapi.plugin_t):
         v = ida_kernwin.get_current_viewer()
         ident, ok = ida_kernwin.get_highlight(v)
         if not ok:
-            print "No identifier was highlighted"
+            print("No identifier was highlighted")
             return
 
         ident = self.sanitize_name(ident)
-        print "Looking up '%s' in MSDN online" % ident
+        print("Looking up '%s' in MSDN online" % ident)
         d = feedparser.parse(get_url(ident))
         if len(d['entries']) > 0:
             url = d['entries'][0].link
@@ -71,7 +72,7 @@ class msdnapihelp_plugin_t(ida_idaapi.plugin_t):
                 import webbrowser
                 webbrowser.open_new_tab(url)
         else:
-            print "API documentation not found for: %s" % ident
+            print("API documentation not found for: %s" % ident)
 
 
     def term(self):

--- a/build.py
+++ b/build.py
@@ -11,6 +11,7 @@
 #---------------------------------------------------------------------
 # build.py - Makefile wrapper script
 #---------------------------------------------------------------------
+from __future__ import print_function
 import os, sys, argparse
 
 parser = argparse.ArgumentParser(epilog="""
@@ -52,7 +53,7 @@ assert os.path.exists(_probe), "Could not find IDA SDK include path (looked for:
 
 def run(proc_argv, env=None):
     import subprocess
-    print "Running: \"%s\", with additional environment: \"%s\"" % (" ".join(proc_argv), str(env))
+    print("Running: \"%s\", with additional environment: \"%s\"" % (" ".join(proc_argv), str(env)))
     full_env = os.environ.copy()
     full_env.update(env)
     subprocess.check_call(proc_argv, env=full_env)
@@ -89,7 +90,7 @@ def main():
         else:
             if "__EA64__" in env:
                 del env["__EA64__"]
-        print "\n### Building EAsize=%d(bit) version of the plugin" % (64 if ea64 else 32)
+        print("\n### Building EAsize=%d(bit) version of the plugin" % (64 if ea64 else 32))
         run(argv, env=env)
 
 # -----------------------------------------------------------------------

--- a/examples/colours.py
+++ b/examples/colours.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #---------------------------------------------------------------------
 # Colour test
 #
@@ -14,6 +15,6 @@ set_color(here(), CIC_FUNC, 0x208020)
 set_color(here(), CIC_ITEM, 0x2020c0)
 
 # Print the colours just set
-print "%x" % get_color(here(), CIC_SEGM)
-print "%x" % get_color(here(), CIC_FUNC)
-print "%x" % get_color(here(), CIC_ITEM)
+print("%x" % get_color(here(), CIC_SEGM))
+print("%x" % get_color(here(), CIC_FUNC))
+print("%x" % get_color(here(), CIC_ITEM))

--- a/examples/debughook.py
+++ b/examples/debughook.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #---------------------------------------------------------------------
 # Debug notification hook test
 #
@@ -32,10 +33,10 @@ class MyDbgHook(DBG_Hooks):
         return 0
 
     def dbg_library_load(self, pid, tid, ea, name, base, size):
-        print "Library loaded: pid=%d tid=%d name=%s base=%x" % (pid, tid, name, base)
+        print("Library loaded: pid=%d tid=%d name=%s base=%x" % (pid, tid, name, base))
 
     def dbg_bpt(self, tid, ea):
-        print "Break point at 0x%x pid=%d" % (ea, tid)
+        print("Break point at 0x%x pid=%d" % (ea, tid))
         # return values:
         #   -1 - to display a breakpoint warning dialog
         #        if the process is suspended.
@@ -44,7 +45,7 @@ class MyDbgHook(DBG_Hooks):
         return 0
 
     def dbg_suspend_process(self):
-        print "Process suspended"
+        print("Process suspended")
 
     def dbg_exception(self, pid, tid, ea, exc_code, exc_can_cont, exc_ea, exc_info):
         print("Exception: pid=%d tid=%d ea=0x%x exc_code=0x%x can_continue=%d exc_ea=0x%x exc_info=%s" % (
@@ -68,7 +69,7 @@ class MyDbgHook(DBG_Hooks):
         self.dbg_step_over()
 
     def dbg_run_to(self, pid, tid=0, ea=0):
-        print "Runto: tid=%d" % tid
+        print("Runto: tid=%d" % tid)
         idaapi.continue_process()
 
 

--- a/examples/ex1_idaapi.py
+++ b/examples/ex1_idaapi.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #
 # Reference Lister
 #
@@ -26,12 +27,12 @@ def main():
     seg_end = seg.end_ea
     while func is not None and func.start_ea < seg_end:
         funcea = func.start_ea
-        print "Function %s at 0x%x" % (get_func_name(funcea), funcea)
+        print("Function %s at 0x%x" % (get_func_name(funcea), funcea))
 
         ref = get_first_cref_to(funcea)
 
         while ref != BADADDR:
-            print "  called from %s(0x%x)" % (get_func_name(ref), ref)
+            print("  called from %s(0x%x)" % (get_func_name(ref), ref))
             ref = get_next_cref_to(funcea, ref)
 
         func = get_next_func(funcea)

--- a/examples/ex1_idautils.py
+++ b/examples/ex1_idautils.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #
 # Reference Lister
 #

--- a/examples/ex_actions.py
+++ b/examples/ex_actions.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import idaapi
 
 class SayHi(idaapi.action_handler_t):
@@ -6,7 +7,7 @@ class SayHi(idaapi.action_handler_t):
         self.message = message
 
     def activate(self, ctx):
-        print "Hi, %s" % (self.message)
+        print("Hi, %s" % (self.message))
         return 1
 
     # You can implement update(), to inform IDA when:
@@ -27,7 +28,7 @@ class SayHi(idaapi.action_handler_t):
         return idaapi.AST_ENABLE_FOR_WIDGET if ctx.widget_type == idaapi.BWN_DISASM else idaapi.AST_DISABLE_FOR_WIDGET
 
 
-print "Creating a custom icon from raw data!"
+print("Creating a custom icon from raw data!")
 # Stunned panda face icon data.
 icon_data = "".join([
         "\x89\x50\x4E\x47\x0D\x0A\x1A\x0A\x00\x00\x00\x0D\x49\x48\x44\x52\x00\x00\x00\x10\x00\x00\x00\x10\x08\x06\x00\x00\x00\x1F\xF3\xFF\x61\x00\x00\x02\xCA\x49\x44\x41\x54\x78\x5E\x65",
@@ -60,19 +61,19 @@ if idaapi.register_action(idaapi.action_desc_t(
         "Ctrl+F12",         # Shortcut (optional)
         "Greets the user",  # Tooltip (optional)
         act_icon)):         # Icon ID (optional)
-    print "Action registered. Attaching to menu."
+    print("Action registered. Attaching to menu.")
 
     # Insert the action in the menu
     if idaapi.attach_action_to_menu("Edit/Export data", act_name, idaapi.SETMENU_APP):
-        print "Attached to menu."
+        print("Attached to menu.")
     else:
-        print "Failed attaching to menu."
+        print("Failed attaching to menu.")
 
     # Insert the action in a toolbar
     if idaapi.attach_action_to_toolbar("AnalysisToolBar", act_name):
-        print "Attached to toolbar."
+        print("Attached to toolbar.")
     else:
-        print "Failed attaching to toolbar."
+        print("Failed attaching to toolbar.")
 
     # We will also want our action to be available in the context menu
     # for the "IDA View-A" widget.
@@ -106,13 +107,13 @@ if idaapi.register_action(idaapi.action_desc_t(
     hooks = Hooks()
     hooks.hook()
 else:
-    print "Action found; unregistering."
+    print("Action found; unregistering.")
     # No need to call detach_action_from_menu(); it'll be
     # done automatically on destruction of the action.
     if idaapi.unregister_action(act_name):
-        print "Unregistered."
+        print("Unregistered.")
     else:
-        print "Failed to unregister action."
+        print("Failed to unregister action.")
 
     if hooks is not None:
         hooks.unhook()

--- a/examples/ex_askusingform.py
+++ b/examples/ex_askusingform.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # -----------------------------------------------------------------------
 # This is an example illustrating how to use the Form class
 # (c) Hex-Rays
@@ -128,15 +129,15 @@ The end!
 def stdalone_main():
     f = MyForm()
     f, args = f.Compile()
-    print args[0]
-    print args[1:]
+    print(args[0])
+    print(args[1:])
     f.rNormal.checked = True
     f.rWarnings.checked = True
-    print hex(f.cGroup1.value)
+    print(hex(f.cGroup1.value))
 
     f.rGreen.selected = True
-    print f.cGroup2.value
-    print "Title: '%s'" % f.title
+    print(f.cGroup2.value)
+    print("Title: '%s'" % f.title)
 
     f.Free()
 
@@ -247,7 +248,7 @@ Form Test
             pass
         elif fid == -2:
             ti = self.GetControlValue(self.txtMultiLineText)
-            print "ti.text = %s" % ti.text
+            print("ti.text = %s" % ti.text)
         else:
             print(">>fid:%d" % fid)
         return 1
@@ -260,13 +261,13 @@ def test_multilinetext(execute=True):
     if execute:
         ok = f.Execute()
     else:
-        print args[0]
-        print args[1:]
+        print(args[0])
+        print(args[1:])
         ok = 0
 
     if ok == 1:
         assert f.txtMultiLineText.text == f.txtMultiLineText.value
-        print f.txtMultiLineText.text
+        print(f.txtMultiLineText.text)
 
     f.Free()
 
@@ -325,7 +326,7 @@ Dropdown list test
             self.RefreshField(self.cbReadonly)
         elif fid == -2:
             s = self.GetControlValue(self.cbEditable)
-            print "user entered: %s" % s
+            print("user entered: %s" % s)
             sel_idx = self.GetControlValue(self.cbReadonly)
 
         return 1
@@ -338,13 +339,13 @@ def test_dropdown(execute=True):
     if execute:
         ok = f.Execute()
     else:
-        print args[0]
-        print args[1:]
+        print(args[0])
+        print(args[1:])
         ok = 0
 
     if ok == 1:
-        print "Editable: %s" % f.cbEditable.value
-        print "Readonly: %s" % f.cbReadonly.value
+        print("Editable: %s" % f.cbEditable.value)
+        print("Readonly: %s" % f.cbReadonly.value)
 
     f.Free()
 

--- a/examples/ex_choose.py
+++ b/examples/ex_choose.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import ida_kernwin
 from ida_kernwin import Choose
 
@@ -10,7 +11,7 @@ class chooser_handler_t(ida_kernwin.action_handler_t):
         sel = []
         for idx in ctx.chooser_selection:
             sel.append(str(idx))
-        print "command %s selected @ %s" % (self.thing, ", ".join(sel))
+        print("command %s selected @ %s" % (self.thing, ", ".join(sel)))
 
     def update(self, ctx):
         return ida_kernwin.AST_ENABLE_FOR_WIDGET \
@@ -45,7 +46,7 @@ class MyChoose(Choose):
         print("created %s" % str(self))
 
     def OnInit(self):
-        print "inited", str(self)
+        print("inited", str(self))
         return True
 
     def OnGetSize(self):
@@ -60,7 +61,7 @@ class MyChoose(Choose):
     def OnGetIcon(self, n):
         r = self.items[n]
         t = self.icon + r[1].count("*")
-        print "geticon", n, t
+        print("geticon", n, t)
         return t
 
     def OnGetLineAttr(self, n):
@@ -95,7 +96,7 @@ class MyChoose(Choose):
         return (Choose.NOTHING_CHANGED, )
 
     def OnClose(self):
-        print "closed", str(self)
+        print("closed", str(self))
 
     def OnPopup(self, form, popup_handle):
         for c in ["A", "B"]:

--- a/examples/ex_choose_multi.py
+++ b/examples/ex_choose_multi.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from ida_kernwin import Choose
 
 
@@ -37,4 +38,4 @@ def test_choose(num):
 
 # -----------------------------------------------------------------------
 if __name__ == '__main__':
-    print test_choose(11)
+    print(test_choose(11))

--- a/examples/ex_cli.py
+++ b/examples/ex_cli.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # -----------------------------------------------------------------------
 # This is an example illustrating how to implement a CLI
 # (c) Hex-Rays
@@ -19,7 +20,7 @@ class mycli_t(cli_t):
         @param line: typed line(s)
         @return Boolean: True-executed line, False-ask for more lines
         """
-        print "OnExecute:", line
+        print("OnExecute:", line)
         return True
 
     def OnKeydown(self, line, x, sellen, vkey, shift):
@@ -40,7 +41,7 @@ class mycli_t(cli_t):
             tuple(line, x, sellen, vkey): if either of the input line or the x coordinate or the selection length has been modified.
             It is possible to return a tuple with None elements to preserve old values. Example: tuple(new_line, None, None, None) or tuple(new_line)
         """
-        print "Onkeydown: line=%s x=%d sellen=%d vkey=%d shift=%d" % (line, x, sellen, vkey, shift)
+        print("Onkeydown: line=%s x=%d sellen=%d vkey=%d shift=%d" % (line, x, sellen, vkey, shift))
         return None
 
     def OnCompleteLine(self, prefix, n, line, prefix_start):
@@ -56,20 +57,20 @@ class mycli_t(cli_t):
 
         @return: None if no completion could be generated otherwise a String with the completion suggestion
         """
-        print "OnCompleteLine: prefix=%s n=%d line=%s prefix_start=%d" % (prefix, n, line, prefix_start)
+        print("OnCompleteLine: prefix=%s n=%d line=%s prefix_start=%d" % (prefix, n, line, prefix_start))
         return None
 
 
 # -----------------------------------------------------------------------
 def nw_handler(code, old=0):
     if code == NW_OPENIDB:
-        print "nw_handler(): installing CLI"
+        print("nw_handler(): installing CLI")
         mycli.register()
     elif code == NW_CLOSEIDB:
-        print "nw_handler(): removing CLI"
+        print("nw_handler(): removing CLI")
         mycli.unregister()
     elif code == NW_TERMIDA:
-        print "nw_handler(): uninstalled nw handler"
+        print("nw_handler(): uninstalled nw handler")
         idaapi.notify_when(NW_TERMIDA | NW_OPENIDB | NW_CLOSEIDB | NW_REMOVE, nw_handler)
 
 # -----------------------------------------------------------------------
@@ -89,10 +90,10 @@ finally:
 
 # register CLI
 if mycli.register():
-    print "CLI installed"
+    print("CLI installed")
     # install new handler
     idaapi.notify_when(NW_TERMIDA | NW_OPENIDB | NW_CLOSEIDB, nw_handler)
 else:
     del mycli
-    print "Failed to install CLI"
+    print("Failed to install CLI")
 

--- a/examples/ex_custdata.py
+++ b/examples/ex_custdata.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # -----------------------------------------------------------------------
 # This is an example illustrating how to use custom data types in Python
 # (c) Hex-Rays
@@ -218,7 +219,7 @@ def nw_handler(code, old=0):
     # delete notifications
     if code == NW_OPENIDB:
         if not idaapi.register_data_types_and_formats(new_formats):
-            print "Failed to register types!"
+            print("Failed to register types!")
     elif code == NW_CLOSEIDB:
         idaapi.unregister_data_types_and_formats(new_formats)
     elif code == NW_TERMIDA:
@@ -228,9 +229,9 @@ def nw_handler(code, old=0):
 # Check if already installed
 if idaapi.find_custom_data_type(pascal_data_format.FORMAT_NAME) == -1:
     if not idaapi.register_data_types_and_formats(new_formats):
-        print "Failed to register types!"
+        print("Failed to register types!")
     else:
         idaapi.notify_when(NW_TERMIDA | NW_OPENIDB | NW_CLOSEIDB, nw_handler)
-        print "Formats installed!"
+        print("Formats installed!")
 else:
-    print "Formats already installed!"
+    print("Formats already installed!")

--- a/examples/ex_custview.py
+++ b/examples/ex_custview.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # -----------------------------------------------------------------------
 # This is an example illustrating how to use customview in Python
 # (c) Hex-Rays
@@ -13,7 +14,7 @@ class say_something_handler_t(idaapi.action_handler_t):
         self.thing = thing
 
     def activate(self, ctx):
-        print self.thing
+        print(self.thing)
 
     def update(self, ctx):
         return idaapi.AST_ENABLE_ALWAYS
@@ -52,7 +53,7 @@ class mycv_t(simplecustviewer_t):
         @param shift: Shift flag
         @return: Boolean. True if you handled the event
         """
-        print "OnClick, shift=%d" % shift
+        print("OnClick, shift=%d" % shift)
         return True
 
     def OnPopup(self, form, popup_handle):
@@ -69,7 +70,7 @@ class mycv_t(simplecustviewer_t):
         """
         word = self.GetCurrentWord()
         if not word: word = "<None>"
-        print "OnDblClick, shift=%d, current word=%s" % (shift, word)
+        print("OnDblClick, shift=%d, current word=%s" % (shift, word))
         return True
 
     def OnCursorPosChanged(self):
@@ -77,14 +78,14 @@ class mycv_t(simplecustviewer_t):
         Cursor position changed.
         @return: Nothing
         """
-        print "OnCurposChanged"
+        print("OnCurposChanged")
 
     def OnClose(self):
         """
         The view is closing. Use this event to cleanup.
         @return: Nothing
         """
-        print "OnClose " + self.title
+        print("OnClose " + self.title)
 
     def OnKeydown(self, vkey, shift):
         """
@@ -93,7 +94,7 @@ class mycv_t(simplecustviewer_t):
         @param shift: Shift flag
         @return: Boolean. True if you handled the event
         """
-        print "OnKeydown, vk=%d shift=%d" % (vkey, shift)
+        print("OnKeydown, vk=%d shift=%d" % (vkey, shift))
         # ESCAPE?
         if vkey == 27:
             self.Close()
@@ -103,7 +104,7 @@ class mycv_t(simplecustviewer_t):
             if n is not None:
                 self.DelLine(n)
                 self.Refresh()
-                print "Deleted line %d" % n
+                print("Deleted line %d" % n)
         # Goto?
         elif vkey == ord('G'):
             n = self.GetLineNo()
@@ -112,17 +113,17 @@ class mycv_t(simplecustviewer_t):
                 if v:
                     self.Jump(v, 0, 5)
         elif vkey == ord('R'):
-            print "refreshing...."
+            print("refreshing....")
             self.Refresh()
         elif vkey == ord('C'):
-            print "refreshing current line..."
+            print("refreshing current line...")
             self.RefreshCurrent()
         elif vkey == ord('A'):
             s = idaapi.ask_str("NewLine%d" % self.Count(), 0, "Append new line")
             self.AddLine(s)
             self.Refresh()
         elif vkey == ord('X'):
-            print "Clearing all lines"
+            print("Clearing all lines")
             self.ClearLines()
             self.Refresh()
         elif vkey == ord('I'):
@@ -135,11 +136,11 @@ class mycv_t(simplecustviewer_t):
             if not l:
                 return False
             n = self.GetLineNo()
-            print "curline=<%s>" % l
+            print("curline=<%s>" % l)
             l = l + idaapi.COLSTR("*", idaapi.SCOLOR_VOIDOP)
             self.EditLine(n, l)
             self.RefreshCurrent()
-            print "Edited line %d" % n
+            print("Edited line %d" % n)
         else:
             return False
         return True
@@ -158,7 +159,7 @@ class mycv_t(simplecustviewer_t):
 try:
     # created already?
     mycv
-    print "Already created, will close it..."
+    print("Already created, will close it...")
     mycv.Close()
     del mycv
 except:
@@ -167,7 +168,7 @@ except:
 def show_win():
     x = mycv_t()
     if not x.Create():
-        print "Failed to create!"
+        print("Failed to create!")
         return None
     x.Show()
     tcc = x.GetWidget()

--- a/examples/ex_dbg.py
+++ b/examples/ex_dbg.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from tempo import *;
 
 def test_getmeminfo():
@@ -12,7 +13,7 @@ def test_getmeminfo():
     f.write("\n".join(out))
     f.close()
 
-    print "dumped meminfo!"
+    print("dumped meminfo!")
 
 
 def test_getregs():
@@ -29,6 +30,6 @@ def test_getregs():
     f.write("\n".join(out))
     f.close()
 
-    print "dumped regs!"
+    print("dumped regs!")
 
 

--- a/examples/ex_debug_names.py
+++ b/examples/ex_debug_names.py
@@ -1,15 +1,16 @@
+from __future__ import print_function
 import idaapi
 
 def main():
     if not idaapi.is_debugger_on():
-        print "Please run the process first!"
+        print("Please run the process first!")
         return
     if idaapi.get_process_state() != -1:
-        print "Please suspend the debugger first!"
+        print("Please suspend the debugger first!")
         return
 
     dn = idaapi.get_debug_names(idaapi.cvar.inf.min_ea, idaapi.cvar.inf.max_ea)
     for i in dn:
-        print "%08x: %s" % (i, dn[i])
+        print("%08x: %s" % (i, dn[i]))
 
 main()

--- a/examples/ex_expr.py
+++ b/examples/ex_expr.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # -----------------------------------------------------------------------
 # This is an example illustrating how to extend IDC from Python
 # (c) Hex-Rays

--- a/examples/ex_func_chooser.py
+++ b/examples/ex_func_chooser.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import idautils
 import idc
 from ida_kernwin import Choose
@@ -39,7 +40,7 @@ class MyChoose(Choose):
         return [Choose.ALL_CHANGED] + self.adjust_last_item(n)
 
     def OnClose(self):
-        print "closed ", self.title
+        print("closed ", self.title)
 
 c = MyChoose("My functions list")
 c.Show()

--- a/examples/ex_gdl_qflow_chart.py
+++ b/examples/ex_gdl_qflow_chart.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import idaapi
 
 # -----------------------------------------------------------------------
@@ -11,15 +12,15 @@ def raw_main(p=True):
     for n in xrange(0, q.size()):
         b = q[n]
         if p:
-            print "%x - %x [%d]:" % (b.start_ea, b.end_ea, n)
+            print("%x - %x [%d]:" % (b.start_ea, b.end_ea, n))
 
         for ns in xrange(0, q.nsucc(n)):
             if p:
-                print "SUCC:  %d->%d" % (n, q.succ(n, ns))
+                print("SUCC:  %d->%d" % (n, q.succ(n, ns)))
 
         for ns in xrange(0, q.npred(n)):
             if p:
-                print "PRED:  %d->%d" % (n, q.pred(n, ns))
+                print("PRED:  %d->%d" % (n, q.pred(n, ns)))
 
 # -----------------------------------------------------------------------
 # Using the class
@@ -27,14 +28,14 @@ def cls_main(p=True):
     f = idaapi.FlowChart(idaapi.get_func(here()))
     for block in f:
         if p:
-            print "%x - %x [%d]:" % (block.start_ea, block.end_ea, block.id)
+            print("%x - %x [%d]:" % (block.start_ea, block.end_ea, block.id))
         for succ_block in block.succs():
             if p:
-                print "  %x - %x [%d]:" % (succ_block.start_ea, succ_block.end_ea, succ_block.id)
+                print("  %x - %x [%d]:" % (succ_block.start_ea, succ_block.end_ea, succ_block.id))
 
         for pred_block in block.preds():
             if p:
-                print "  %x - %x [%d]:" % (pred_block.start_ea, pred_block.end_ea, pred_block.id)
+                print("  %x - %x [%d]:" % (pred_block.start_ea, pred_block.end_ea, pred_block.id))
 
 q = None
 f = None

--- a/examples/ex_graph.py
+++ b/examples/ex_graph.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # -----------------------------------------------------------------------
 # This is an example illustrating how to use the user graphing functionality
 # in Python
@@ -66,7 +67,7 @@ class MyGraph(GraphViewer):
 def show_graph():
     f = idaapi.get_func(here())
     if not f:
-        print "Must be in a function"
+        print("Must be in a function")
         return
     # Iterate through all function instructions and take only call instructions
     result = {}
@@ -86,4 +87,4 @@ def show_graph():
 
 g = show_graph()
 if g:
-    print "Graph created and displayed!"
+    print("Graph created and displayed!")

--- a/examples/ex_hexrays.py
+++ b/examples/ex_hexrays.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #
 # This example tries to load a decompiler plugin corresponding to the current
 # architecture (and address size) right after auto-analysis is performed,

--- a/examples/ex_hotkey.py
+++ b/examples/ex_hotkey.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #---------------------------------------------------------------------
 # This script demonstrates the usage of hotkeys.
 #

--- a/examples/ex_idagraph.py
+++ b/examples/ex_idagraph.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # -----------------------------------------------------------------------
 # This is an example illustrating how to manipulate an existing IDA-provided
 # view (and thus its graph), in Python.
@@ -15,21 +16,21 @@ class Worker(threading.Thread):
     def req_SetCurrentRendererType(self, switch_to):
         w = self.w
         def f():
-            print "Switching.."
+            print("Switching..")
             w.SetCurrentRendererType(switch_to)
         idaapi.execute_sync(f, idaapi.MFF_FAST)
 
     def req_SetNodeInfo(self, node, info, flags):
         w = self.w
         def f():
-            print "Setting node info.."
+            print("Setting node info..")
             w.SetNodeInfo(node, info, flags)
         idaapi.execute_sync(f, idaapi.MFF_FAST)
 
     def req_DelNodesInfos(self, *nodes):
         w = self.w
         def f():
-            print "Deleting nodes infos.."
+            print("Deleting nodes infos..")
             w.DelNodesInfos(*nodes)
         idaapi.execute_sync(f, idaapi.MFF_FAST)
 
@@ -63,7 +64,7 @@ class Worker(threading.Thread):
         self.req_DelNodesInfos(0)
         sleep(3)
 
-        print "Done."
+        print("Done.")
 
 class MyIDAViewWrapper(IDAViewWrapper):
     # A wrapper around the standard IDA view wrapper.
@@ -79,9 +80,9 @@ class MyIDAViewWrapper(IDAViewWrapper):
         stack = inspect.stack()
         frame, _, _, _, _, _ = stack[1]
         args, _, _, values = inspect.getargvalues(frame)
-        print "EVENT: %s: args=%s" % (
+        print("EVENT: %s: args=%s" % (
             inspect.getframeinfo(frame)[2],
-            [(i, values[i]) for i in args[1:]])
+            [(i, values[i]) for i in args[1:]]))
 
     def OnViewKeydown(self, key, state):
         self.printPrevFrame()
@@ -103,7 +104,7 @@ class MyIDAViewWrapper(IDAViewWrapper):
 viewName = "IDA View-A"
 w = MyIDAViewWrapper(viewName)
 if w.Bind():
-    print "Succesfully bound to %s" % viewName
+    print("Succesfully bound to %s" % viewName)
 
     # We'll launch the sequence of operations in another thread,
     # so that sleep() calls don't freeze the UI
@@ -111,4 +112,4 @@ if w.Bind():
     worker.start()
 
 else:
-    print "Couldn't bind to view %s. Is it available?" % viewName
+    print("Couldn't bind to view %s. Is it available?" % viewName)

--- a/examples/ex_idphook_asm.py
+++ b/examples/ex_idphook_asm.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import idaapi
 import idautils
 

--- a/examples/ex_imports.py
+++ b/examples/ex_imports.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # -----------------------------------------------------------------------
 # This is an example illustrating how to enumerate imports
 # (c) Hex-Rays
@@ -6,24 +7,24 @@ import idaapi
 
 def imp_cb(ea, name, ord):
     if not name:
-        print "%08x: ord#%d" % (ea, ord)
+        print("%08x: ord#%d" % (ea, ord))
     else:
-        print "%08x: %s (ord#%d)" % (ea, name, ord)
+        print("%08x: %s (ord#%d)" % (ea, name, ord))
     # True -> Continue enumeration
     # False -> Stop enumeration
     return True
 
 nimps = idaapi.get_import_module_qty()
 
-print "Found %d import(s)..." % nimps
+print("Found %d import(s)..." % nimps)
 
 for i in xrange(0, nimps):
     name = idaapi.get_import_module_name(i)
     if not name:
-        print "Failed to get import module name for #%d" % i
+        print("Failed to get import module name for #%d" % i)
         continue
 
-    print "Walking-> %s" % name
+    print("Walking-> %s" % name)
     idaapi.enum_import_names(i, imp_cb)
 
-print "All done..."
+print("All done...")

--- a/examples/ex_patch.py
+++ b/examples/ex_patch.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # -------------------------------------------------------------------------
 # This is an example illustrating how to visit all patched bytes in Python
 # (c) Hex-Rays

--- a/examples/ex_prefix_plugin.py
+++ b/examples/ex_prefix_plugin.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import idaapi
 
 PREFIX = idaapi.SCOLOR_INV + ' ' + idaapi.SCOLOR_INV

--- a/examples/ex_procext.py
+++ b/examples/ex_procext.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # this script implements disassembly of BUG_INSTR used in Linux kernel BUG() macro 
 # normally it's architecturally undefined and is not disassembled by IDA's ARM module
 # see Linux/arch/arm/include/asm/bug.h
@@ -37,7 +38,7 @@ class MyHooks(idaapi.IDP_Hooks):
 if idaapi.ph.id == idaapi.PLFM_ARM:
     bahooks = MyHooks()
     bahooks.hook()
-    print "BUG_INSTR processor extension installed"
+    print("BUG_INSTR processor extension installed")
 else:
     warning("This script only supports ARM files")
 

--- a/examples/ex_strings.py
+++ b/examples/ex_strings.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import idautils
 
 s = idautils.Strings(False)

--- a/examples/ex_sync_graphs.py
+++ b/examples/ex_sync_graphs.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 from idaapi import *
 

--- a/examples/ex_timer.py
+++ b/examples/ex_timer.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # -------------------------------------------------------------------------
 # This is an example illustrating how to use timers
 # (c) Hex-Rays
@@ -10,7 +11,7 @@ class timercallback_t(object):
         self.interval = 1000
         self.obj = idaapi.register_timer(self.interval, self)
         if self.obj is None:
-            raise RuntimeError, "Failed to register timer"
+            raise RuntimeError("Failed to register timer")
         self.times = 5
 
     def __call__(self):
@@ -30,7 +31,7 @@ def main():
 		# No need to unregister the timer.
 		# It will unregister itself in the callback when it returns -1
     except Exception as e:
-        print "Error: %s" % e
+        print("Error: %s" % e)
 
 
 # -------------------------------------------------------------------------

--- a/examples/ex_uihook.py
+++ b/examples/ex_uihook.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #---------------------------------------------------------------------
 # UI hook example
 #

--- a/examples/ex_uirequests.py
+++ b/examples/ex_uirequests.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # -----------------------------------------------------------------------
 # This is an example illustrating how to use the execute_ui_requests()
 # and the idautils.ProcessUiActions()
@@ -16,7 +17,7 @@ class __process_ui_actions_helper(object):
         elif isinstance(actions, (list, tuple)):
             lst = actions
         else:
-            raise ValueError, "Must pass a string, list or a tuple"
+            raise ValueError("Must pass a string, list or a tuple")
 
         # Remember the action list and the flags
         self.__action_list = lst
@@ -39,7 +40,7 @@ class __process_ui_actions_helper(object):
 
         # Move to next action
         self.__idx += 1
-        print "index=%d" % self.__idx
+        print("index=%d" % self.__idx)
 
         # Reschedule
         return True

--- a/examples/hotkey.py
+++ b/examples/hotkey.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #---------------------------------------------------------------------
 # This script demonstrates the usage of hotkeys.
 #
@@ -9,7 +10,7 @@
 import idaapi
 
 def foo():
- print "Hotkey activated!"
+ print("Hotkey activated!")
 
 # IDA binds hotkeys to IDC functions so a trampoline IDC function
 # must be created

--- a/examples/structure.py
+++ b/examples/structure.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #---------------------------------------------------------------------
 # Structure test
 #
@@ -12,7 +13,7 @@ sid = get_struc_id("mystr1")
 if sid != -1:
     del_struc(sid)
 sid = add_struc(-1, "mystr1", 0)
-print "%x" % sid
+print("%x" % sid)
 
 # Test simple data types
 simple_types = [ FF_BYTE, FF_WORD, FF_DWORD, FF_QWORD, FF_TBYTE, FF_OWORD, FF_FLOAT, FF_DOUBLE, FF_PACKREAL ]
@@ -20,11 +21,11 @@ simple_sizes = [ 1, 2, 4, 8, 10, 16, 4, 8, 10 ]
 
 i = 0
 for t,nsize in zip(simple_types, simple_sizes):
-    print "t%x:"% ((t|FF_DATA)&0xFFFFFFFF), add_struc_member(sid, "t%02d"%i, BADADDR, (t|FF_DATA )&0xFFFFFFFF, -1, nsize)
+    print("t%x:"% ((t|FF_DATA)&0xFFFFFFFF), add_struc_member(sid, "t%02d"%i, BADADDR, (t|FF_DATA )&0xFFFFFFFF, -1, nsize))
     i+=1
 
 # Test ASCII type
-print "ASCII:", add_struc_member(sid, "tascii", -1, FF_STRLIT|FF_DATA, STRTYPE_C, 8)
+print("ASCII:", add_struc_member(sid, "tascii", -1, FF_STRLIT|FF_DATA, STRTYPE_C, 8))
 
 # Test enum type - Add a defined enum name or load MACRO_WMI from a type library.
 #eid = get_enum("MACRO_WMI")
@@ -35,15 +36,15 @@ msid = get_struc_id("mystr2")
 if msid != -1:
     del_struc(msid)
 msid = add_struc(-1, "mystr2", 0)
-print add_struc_member(msid, "member1", -1, (FF_DWORD|FF_DATA )&0xFFFFFFFF, -1, 4)
-print add_struc_member(msid, "member2", -1, (FF_DWORD|FF_DATA )&0xFFFFFFFF, -1, 4)
+print(add_struc_member(msid, "member1", -1, (FF_DWORD|FF_DATA )&0xFFFFFFFF, -1, 4))
+print(add_struc_member(msid, "member2", -1, (FF_DWORD|FF_DATA )&0xFFFFFFFF, -1, 4))
 
 msize = get_struc_size(msid)
-print "Struct:", add_struc_member(sid, "tstruct", -1, FF_STRUCT|FF_DATA, msid, msize)
-print "Stroff:", add_struc_member(sid, "tstroff", -1, stroffflag()|FF_DWORD, msid, 4)
+print("Struct:", add_struc_member(sid, "tstruct", -1, FF_STRUCT|FF_DATA, msid, msize))
+print("Stroff:", add_struc_member(sid, "tstroff", -1, stroffflag()|FF_DWORD, msid, 4))
 
 # Test offset types
-print "Offset:", add_struc_member(sid, "toffset", -1, offflag()|FF_DATA|FF_DWORD, 0, 4)
-print "Offset:", set_member_type(sid, 0, offflag()|FF_DATA|FF_DWORD, 0, 4)
+print("Offset:", add_struc_member(sid, "toffset", -1, offflag()|FF_DATA|FF_DWORD, 0, 4))
+print("Offset:", set_member_type(sid, 0, offflag()|FF_DATA|FF_DWORD, 0, 4))
 
-print "Done"
+print("Done")

--- a/examples/vds1.py
+++ b/examples/vds1.py
@@ -1,24 +1,25 @@
+from __future__ import print_function
 import idaapi
 
 def main():
     if not idaapi.init_hexrays_plugin():
         return False
 
-    print "Hex-rays version %s has been detected" % idaapi.get_hexrays_version()
+    print("Hex-rays version %s has been detected" % idaapi.get_hexrays_version())
 
     f = idaapi.get_func(idaapi.get_screen_ea());
     if f is None:
-        print "Please position the cursor within a function"
+        print("Please position the cursor within a function")
         return True
 
     cfunc = idaapi.decompile(f);
     if cfunc is None:
-        print "Failed to decompile!"
+        print("Failed to decompile!")
         return True
 
     sv = cfunc.get_pseudocode();
     for sline in sv:
-        print idaapi.tag_remove(sline.line);
+        print(idaapi.tag_remove(sline.line));
 
     return True
 

--- a/examples/vds3.py
+++ b/examples/vds3.py
@@ -4,6 +4,7 @@ Author: EiNSTeiN_ <einstein@g3nius.org>
 
 This is a rewrite in Python of the vds3 example that comes with hexrays sdk.
 """
+from __future__ import print_function
 
 import idautils
 import idaapi
@@ -53,9 +54,9 @@ class hexrays_callback_info(object):
             data = self.node.getblob(0, 'I')
             if data:
                 self.stored = eval(data)
-                print 'Invert-if: Loaded %s' % (repr(self.stored), )
+                print('Invert-if: Loaded %s' % (repr(self.stored), ))
         except:
-            print 'Failed to load invert-if locations'
+            print('Failed to load invert-if locations')
             traceback.print_exc()
             return
 
@@ -66,7 +67,7 @@ class hexrays_callback_info(object):
         try:
             self.node.setblob(repr(self.stored), 0, 'I')
         except:
-            print 'Failed to save invert-if locations'
+            print('Failed to save invert-if locations')
             traceback.print_exc()
             return
 
@@ -195,5 +196,5 @@ if idaapi.init_hexrays_plugin():
     vds3_hooks = vds3_hooks_t(i)
     vds3_hooks.hook()
 else:
-    print 'invert-if: hexrays is not available.'
+    print('invert-if: hexrays is not available.')
 

--- a/examples/vds4.py
+++ b/examples/vds4.py
@@ -4,6 +4,7 @@ Author: EiNSTeiN_ <einstein@g3nius.org>
 
 This is a rewrite in Python of the vds4 example that comes with hexrays sdk.
 """
+from __future__ import print_function
 
 import idautils
 import idaapi
@@ -15,74 +16,74 @@ def run():
 
     cfunc = idaapi.decompile(idaapi.get_screen_ea())
     if not cfunc:
-        print 'Please move the cursor into a function.'
+        print('Please move the cursor into a function.')
         return
 
     entry_ea = cfunc.entry_ea
-    print "Dump of user-defined information for function at %x" % (entry_ea, )
+    print("Dump of user-defined information for function at %x" % (entry_ea, ))
 
     # Display user defined labels.
     labels = idaapi.restore_user_labels(entry_ea);
     if labels is not None:
-        print "------- %u user defined labels" % (len(labels), )
+        print("------- %u user defined labels" % (len(labels), ))
         for org_label, name in labels.iteritems():
-            print "Label %d: %s" % (org_label, str(name))
+            print("Label %d: %s" % (org_label, str(name)))
         idaapi.user_labels_free(labels)
 
     # Display user defined comments
     cmts = idaapi.restore_user_cmts(entry_ea);
     if cmts is not None:
-        print "------- %u user defined comments" % (len(cmts), )
+        print("------- %u user defined comments" % (len(cmts), ))
         for tl, cmt in cmts.iteritems():
-            print "Comment at %x, preciser %x:\n%s\n" % (tl.ea, tl.itp, str(cmt))
+            print("Comment at %x, preciser %x:\n%s\n" % (tl.ea, tl.itp, str(cmt)))
         idaapi.user_cmts_free(cmts)
 
     # Display user defined citem iflags
     iflags = idaapi.restore_user_iflags(entry_ea)
     if iflags is not None:
-        print "------- %u user defined citem iflags" % (len(iflags), )
+        print("------- %u user defined citem iflags" % (len(iflags), ))
         for cl, f in iflags.iteritems():
-            print "%x(%d): %08X%s" % (cl.ea, cl.op, f, " CIT_COLLAPSED" if f & idaapi.CIT_COLLAPSED else "")
+            print("%x(%d): %08X%s" % (cl.ea, cl.op, f, " CIT_COLLAPSED" if f & idaapi.CIT_COLLAPSED else ""))
         idaapi.user_iflags_free(iflags)
 
     # Display user defined number formats
     numforms = idaapi.restore_user_numforms(entry_ea)
     if numforms is not None:
-        print "------- %u user defined number formats" % (len(numforms), )
+        print("------- %u user defined number formats" % (len(numforms), ))
         for ol, nf in numforms.iteritems():
 
-            print "Number format at %a, operand %d: %s" % (ol.ea, ol.opnum, "negated " if (nf.props & NF_NEGATE) != 0 else "")
+            print("Number format at %a, operand %d: %s" % (ol.ea, ol.opnum, "negated " if (nf.props & NF_NEGATE) != 0 else ""))
 
             if nf.is_enum():
-                print "enum %s (serial %d)" % (str(nf.type_name), nf.serial)
+                print("enum %s (serial %d)" % (str(nf.type_name), nf.serial))
 
             elif nf.is_char():
-                print "char"
+                print("char")
 
             elif nf.is_stroff():
-                print "struct offset %s" % (str(nf.type_name), )
+                print("struct offset %s" % (str(nf.type_name), ))
 
             else:
-                print "number base=%d" % (idaapi.get_radix(nf.flags, ol.opnum), )
+                print("number base=%d" % (idaapi.get_radix(nf.flags, ol.opnum), ))
 
         idaapi.user_numforms_free(numforms)
 
     # Display user-defined local variable information
     lvinf = idaapi.lvar_uservec_t()
     if idaapi.restore_user_lvar_settings(lvinf, entry_ea):
-        print "------- User defined local variable information\n"
+        print("------- User defined local variable information\n")
         for lv in lvinf.lvvec:
-            print "Lvar defined at %x" % (lv.ll.defea, )
+            print("Lvar defined at %x" % (lv.ll.defea, ))
 
             if len(str(lv.name)):
-                print "  Name: %s" % (str(lv.name), )
+                print("  Name: %s" % (str(lv.name), ))
 
             if len(str(lv.type)):
                 #~ print_type_to_one_line(buf, sizeof(buf), idati, .c_str());
-                print "  Type: %s" % (str(lv.type), )
+                print("  Type: %s" % (str(lv.type), ))
 
             if len(str(lv.cmt)):
-                print "  Comment: %s" % (str(lv.cmt), )
+                print("  Comment: %s" % (str(lv.cmt), ))
 
 
     return
@@ -91,4 +92,4 @@ def run():
 if idaapi.init_hexrays_plugin():
     run()
 else:
-    print 'dump user info: hexrays is not available.'
+    print('dump user info: hexrays is not available.')

--- a/examples/vds5.py
+++ b/examples/vds5.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 import ida_pro
 import ida_hexrays
@@ -305,5 +306,5 @@ if ida_hexrays.init_hexrays_plugin():
     vds5_hooks = vds5_hooks_t()
     vds5_hooks.hook()
 else:
-    print 'hexrays-graph: hexrays is not available.'
+    print('hexrays-graph: hexrays is not available.')
 

--- a/examples/vds6.py
+++ b/examples/vds6.py
@@ -5,6 +5,7 @@ hexrays plugin 'hexrays_sample6.cpp', shipped with the Hex-Rays decompiler.
 
 It modifies the decompilation output: removes some space characters.
 """
+from __future__ import print_function
 
 import idautils
 import idc
@@ -91,4 +92,4 @@ if ida_hexrays.init_hexrays_plugin():
     vds6_hooks = vds6_hooks_t()
     vds6_hooks.hook()
 else:
-    print 'remove spaces: hexrays is not available.'
+    print('remove spaces: hexrays is not available.')

--- a/examples/vds7.py
+++ b/examples/vds7.py
@@ -4,6 +4,7 @@ Author: EiNSTeiN_ <einstein@g3nius.org>
 
 This is a rewrite in Python of the vds7 example that comes with hexrays sdk.
 """
+from __future__ import print_function
 
 import idautils
 import idaapi
@@ -29,9 +30,9 @@ class cblock_visitor_t(idaapi.ctree_visitor_t):
 
     def dump_block(self, ea, b):
         # iterate over all block instructions
-        print "dumping block %x" % (ea, )
+        print("dumping block %x" % (ea, ))
         for ins in b:
-            print "  %x: insn %s" % (ins.ea, ins.opname)
+            print("  %x: insn %s" % (ins.ea, ins.opname))
 
         return
 
@@ -48,4 +49,4 @@ if idaapi.init_hexrays_plugin():
     vds7_hooks = vds7_hooks_t()
     vds7_hooks.hook()
 else:
-    print 'cblock visitor: hexrays is not available.'
+    print('cblock visitor: hexrays is not available.')

--- a/examples/vds_hooks.py
+++ b/examples/vds_hooks.py
@@ -1,6 +1,7 @@
 """
 Various hooks for Hexrays Decompiler
 """
+from __future__ import print_function
 
 import ida_typeinf
 import ida_hexrays

--- a/examples/vds_xrefs.py
+++ b/examples/vds_xrefs.py
@@ -8,6 +8,7 @@ Show decompiler-style Xref when the X key is pressed in the Decompiler window.
 - It supports structure member.
 
 """
+from __future__ import print_function
 
 import idautils
 import idaapi
@@ -114,9 +115,9 @@ class XrefsForm(idaapi.PluginForm):
 
     def get_decompiled_line(self, cfunc, ea):
 
-        print repr(ea)
+        print(repr(ea))
         if ea not in cfunc.eamap:
-            print 'strange, %x is not in %x eamap' % (ea, cfunc.entry_ea)
+            print('strange, %x is not in %x eamap' % (ea, cfunc.entry_ea))
             return
 
         insnvec = cfunc.eamap[ea]
@@ -147,7 +148,7 @@ class XrefsForm(idaapi.PluginForm):
                 self.items.append((ea, idc.get_func_name(cfunc.entry_ea), self.get_decompiled_line(cfunc, ea)))
 
             except Exception as e:
-                print 'could not decompile: %s' % (str(e), )
+                print('could not decompile: %s' % (str(e), ))
                 raise
 
         return
@@ -167,7 +168,7 @@ class XrefsForm(idaapi.PluginForm):
             try:
                 cfunc = idaapi.decompile(ea)
             except:
-                print 'Decompilation of %x failed' % (ea, )
+                print('Decompilation of %x failed' % (ea, ))
                 continue
 
             str(cfunc)
@@ -195,14 +196,14 @@ class XrefsForm(idaapi.PluginForm):
                     parent = cfunc.body.find_parent_of(parent)
 
                 if not parent:
-                    print 'cannot find parent statement (?!)'
+                    print('cannot find parent statement (?!)')
                     continue
 
                 if parent.ea in addresses:
                     continue
 
                 if parent.ea == idaapi.BADADDR:
-                    print 'parent.ea is BADADDR'
+                    print('parent.ea is BADADDR')
                     continue
 
                 addresses.append(parent.ea)
@@ -259,7 +260,7 @@ class show_xrefs_ah_t(idaapi.action_handler_t):
     def activate(self, ctx):
         vu = idaapi.get_widget_vdui(ctx.widget)
         if not vu or not self.sel:
-            print "No vdui? Strange, since this action should be enabled only for pseudocode views."
+            print("No vdui? Strange, since this action should be enabled only for pseudocode views.")
             return 0
 
         form = XrefsForm(self.sel)
@@ -296,6 +297,6 @@ if idaapi.init_hexrays_plugin():
         vds_xrefs_hooks = vds_xrefs_hooks_t()
         vds_xrefs_hooks.hook()
     else:
-        print "Couldn't register action."
+        print("Couldn't register action.")
 else:
-    print 'hexrays is not available.'
+    print('hexrays is not available.')

--- a/python/idadex.py
+++ b/python/idadex.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #---------------------------------------------------------------------
 # IDAPython - Python plugin for Interactive Disassembler
 #
@@ -26,7 +27,7 @@ uint64 = ctypes.c_uint64
 uint16 = ctypes.c_ushort
 ushort = uint16
 # __EA64__ is set if IDA is running in 64-bit mode
-__EA64__ = ida_idaapi.BADADDR == 0xFFFFFFFFFFFFFFFFL
+__EA64__ = ida_idaapi.BADADDR == 0xFFFFFFFFFFFFFFFF
 ea_t = uint64 if __EA64__ else uint32
 
 # parse a ctypes struct from byte data in str_ at 'off'
@@ -92,8 +93,8 @@ def unpack_dq(buf, off):
     (xl, off) = unpack_dd(buf, off)
     (xh, off) = unpack_dd(buf, off)
     x = (long(xh) << 32) | xl
-    if x > 0x8000000000000000L:
-        x = x - 0x10000000000000000L
+    if x > 0x8000000000000000:
+        x = x - 0x10000000000000000
     return (x, off)
 
 def unpack_ea(buf, off):
@@ -282,7 +283,7 @@ class Dex(object):
         nn_var = self.get_nn_var(from_ea)
         val = nn_var.supval(method_idx, Dex.DEXVAR_METHOD)
         if len(val) != ctypes.sizeof(dex_method):
-            print "bad data in DEXVAR_METHOD for index 0x%X" % method_idx
+            print("bad data in DEXVAR_METHOD for index 0x%X" % method_idx)
             return None
         method = get_struct(val,0, dex_method)
         return method
@@ -430,7 +431,7 @@ class Dex(object):
         nn_var = self.get_nn_var(from_ea)
         val = nn_var.supval(field_idx, Dex.DEXVAR_FIELD)
         if len(val) != ctypes.sizeof(dex_field):
-            print "bad data in DEXVAR_FIELD for index 0x%X" % field_idx
+            print("bad data in DEXVAR_FIELD for index 0x%X" % field_idx)
             return None
         field = get_struct(val,0, dex_field)
         return field
@@ -462,14 +463,14 @@ if __name__ == '__main__':
     # reproduce IDA function header
     f = idaapi.get_func(here())
     if not f:
-        print "ERROR: must be in a function!"
+        print("ERROR: must be in a function!")
         exit(1)
 
     func_start_ea = f.start_ea
     methno = dex.get_method_idx(func_start_ea)
     func_method = dex.get_method(func_start_ea, methno)
     if func_method is None:
-        print "ERROR: Missing method info"
+        print("ERROR: Missing method info")
         exit(1)
     out = ""
     # Return type
@@ -495,9 +496,9 @@ if __name__ == '__main__':
         out += "%x" % methno
     # Method parameters
     if func_method.nparams == 0:
-        print out + "()"
+        print(out + "()")
     else:
-        print out + "("
+        print(out + "(")
         out = ""
         maxp = min(func_method.nparams, 32)
         start_reg = func_method.reg_total - func_method.reg_params
@@ -519,4 +520,4 @@ if __name__ == '__main__':
             else:
                 out += r.user
             out += ')' if i + 1 == maxp else ','
-            print out
+            print(out)

--- a/python/idautils.py
+++ b/python/idautils.py
@@ -263,7 +263,7 @@ def Chunks(start):
     while status:
         chunk = func_iter.chunk()
         yield (chunk.start_ea, chunk.end_ea)
-        status = func_iter.next()
+        status = next(func_iter)
 
 
 def Modules():
@@ -419,7 +419,7 @@ def GetDataList(ea, count, itemsize=1):
     elif itemsize == 8:
         getdata = ida_bytes.get_qword
     else:
-        raise ValueError, "Invalid data size! Must be 1, 2, 4 or 8"
+        raise ValueError("Invalid data size! Must be 1, 2, 4 or 8")
 
     endea = ea + itemsize * count
     curea = ea
@@ -593,7 +593,7 @@ def _Assemble(ea, line):
     """
     Please refer to Assemble() - INTERNAL USE ONLY
     """
-    if type(line) == types.StringType:
+    if type(line) == bytes:
         lines = [line]
     else:
         lines = line
@@ -636,7 +636,7 @@ def _copy_obj(src, dest, skip_list = None):
                  Otherwise dest should be an instance of another class
     @return: A new instance or "dest"
     """
-    if type(dest) == types.StringType:
+    if type(dest) == bytes:
         # instantiate a new destination class of the specified type name?
         dest = new.classobj(dest, (), {})
     for x in dir(src):
@@ -703,7 +703,7 @@ class __process_ui_actions_helper(object):
         elif isinstance(actions, (list, tuple)):
             lst = actions
         else:
-            raise ValueError, "Must pass a string, list or a tuple"
+            raise ValueError("Must pass a string, list or a tuple")
 
         # Remember the action list and the flags
         self.__action_list = lst

--- a/python/idc.py
+++ b/python/idc.py
@@ -25,6 +25,7 @@ the byte value). These 32 bits are used in get_full_flags/get_flags functions.
 This file is subject to change without any notice.
 Future versions of IDA may use other definitions.
 """
+from __future__ import print_function
 # FIXME: Perhaps those should be loaded on-demand
 import ida_idaapi
 import ida_auto
@@ -68,7 +69,7 @@ import time
 import types
 import sys
 
-__EA64__ = ida_idaapi.BADADDR == 0xFFFFFFFFFFFFFFFFL
+__EA64__ = ida_idaapi.BADADDR == 0xFFFFFFFFFFFFFFFF
 WORDMASK = 0xFFFFFFFFFFFFFFFF if __EA64__ else 0xFFFFFFFF
 class DeprecatedIDCError(Exception):
     """
@@ -94,7 +95,7 @@ def _IDC_GetAttr(obj, attrmap, attroffs):
         return getattr(obj, attrmap[attroffs][1])
     else:
         errormsg = "attribute with offset %d not found, check the offset and report the problem" % attroffs
-        raise KeyError, errormsg
+        raise KeyError(errormsg)
 
 
 def _IDC_SetAttr(obj, attrmap, attroffs, value):
@@ -105,11 +106,11 @@ def _IDC_SetAttr(obj, attrmap, attroffs, value):
     # check for read-only atributes
     if attroffs in attrmap:
         if attrmap[attroffs][0]:
-            raise KeyError, "attribute with offset %d is read-only" % attroffs
+            raise KeyError("attribute with offset %d is read-only" % attroffs)
         elif hasattr(obj, attrmap[attroffs][1]):
             return setattr(obj, attrmap[attroffs][1], value)
     errormsg = "attribute with offset %d not found, check the offset and report the problem" % attroffs
-    raise KeyError, errormsg
+    raise KeyError(errormsg)
 
 
 BADADDR         = ida_idaapi.BADADDR # Not allowed address value
@@ -293,12 +294,12 @@ NEF_FLAT   = ida_loader.NEF_FLAT   # Autocreated FLAT group (PE)
 # ----------------------------------------------------------------------------
 #                       M I S C E L L A N E O U S
 # ----------------------------------------------------------------------------
-def value_is_string(var): raise NotImplementedError, "this function is not needed in Python"
-def value_is_long(var):   raise NotImplementedError, "this function is not needed in Python"
-def value_is_float(var):  raise NotImplementedError, "this function is not needed in Python"
-def value_is_func(var):   raise NotImplementedError, "this function is not needed in Python"
-def value_is_pvoid(var):  raise NotImplementedError, "this function is not needed in Python"
-def value_is_int64(var):  raise NotImplementedError, "this function is not needed in Python"
+def value_is_string(var): raise NotImplementedError("this function is not needed in Python")
+def value_is_long(var):   raise NotImplementedError("this function is not needed in Python")
+def value_is_float(var):  raise NotImplementedError("this function is not needed in Python")
+def value_is_func(var):   raise NotImplementedError("this function is not needed in Python")
+def value_is_pvoid(var):  raise NotImplementedError("this function is not needed in Python")
+def value_is_int64(var):  raise NotImplementedError("this function is not needed in Python")
 
 def to_ea(seg, off):
     """
@@ -307,19 +308,19 @@ def to_ea(seg, off):
     return (seg << 4) + off
 
 def form(format, *args):
-    raise DeprecatedIDCError, "form() is deprecated. Use python string operations instead."
+    raise DeprecatedIDCError("form() is deprecated. Use python string operations instead.")
 
 def substr(s, x1, x2):
-    raise DeprecatedIDCError, "substr() is deprecated. Use python string operations instead."
+    raise DeprecatedIDCError("substr() is deprecated. Use python string operations instead.")
 
 def strstr(s1, s2):
-    raise DeprecatedIDCError, "strstr() is deprecated. Use python string operations instead."
+    raise DeprecatedIDCError("strstr() is deprecated. Use python string operations instead.")
 
 def strlen(s):
-    raise DeprecatedIDCError, "strlen() is deprecated. Use python string operations instead."
+    raise DeprecatedIDCError("strlen() is deprecated. Use python string operations instead.")
 
 def xtol(s):
-    raise DeprecatedIDCError, "xtol() is deprecated. Use python long() instead."
+    raise DeprecatedIDCError("xtol() is deprecated. Use python long() instead.")
 
 def atoa(ea):
     """
@@ -332,10 +333,10 @@ def atoa(ea):
     return ida_kernwin.ea2str(ea)
 
 def ltoa(n, radix):
-    raise DeprecatedIDCError, "ltoa() is deprecated. Use python string operations instead."
+    raise DeprecatedIDCError("ltoa() is deprecated. Use python string operations instead.")
 
 def atol(s):
-    raise DeprecatedIDCError, "atol() is deprecated. Use python long() instead."
+    raise DeprecatedIDCError("atol() is deprecated. Use python long() instead.")
 
 
 def rotate_left(value, count, nbits, offset):
@@ -414,7 +415,7 @@ def eval_idc(expr):
         elif rv.vtype == '\x07': # VT_STR
             return rv.c_str()
         else:
-            raise NotImplementedError, "eval_idc() supports only expressions returning strings or longs"
+            raise NotImplementedError("eval_idc() supports only expressions returning strings or longs")
 
 
 def EVAL_FAILURE(code):
@@ -425,7 +426,7 @@ def EVAL_FAILURE(code):
 
     @return: True if there was an evaluation error
     """
-    return type(code) == types.StringType and code.startswith("IDC_FAILURE: ")
+    return type(code) == bytes and code.startswith("IDC_FAILURE: ")
 
 
 def save_database(idbname, flags=0):
@@ -855,15 +856,15 @@ def set_array_params(ea, flags, litems, align):
     """
     return eval_idc("set_array_params(0x%X, 0x%X, %d, %d)"%(ea, flags, litems, align))
 
-AP_ALLOWDUPS    = 0x00000001L     # use 'dup' construct
-AP_SIGNED       = 0x00000002L     # treats numbers as signed
-AP_INDEX        = 0x00000004L     # display array element indexes as comments
-AP_ARRAY        = 0x00000008L     # reserved (this flag is not stored in database)
-AP_IDXBASEMASK  = 0x000000F0L     # mask for number base of the indexes
-AP_IDXDEC       = 0x00000000L     # display indexes in decimal
-AP_IDXHEX       = 0x00000010L     # display indexes in hex
-AP_IDXOCT       = 0x00000020L     # display indexes in octal
-AP_IDXBIN       = 0x00000030L     # display indexes in binary
+AP_ALLOWDUPS    = 0x00000001     # use 'dup' construct
+AP_SIGNED       = 0x00000002     # treats numbers as signed
+AP_INDEX        = 0x00000004     # display array element indexes as comments
+AP_ARRAY        = 0x00000008     # reserved (this flag is not stored in database)
+AP_IDXBASEMASK  = 0x000000F0     # mask for number base of the indexes
+AP_IDXDEC       = 0x00000000     # display indexes in decimal
+AP_IDXHEX       = 0x00000010     # display indexes in hex
+AP_IDXOCT       = 0x00000020     # display indexes in octal
+AP_IDXBIN       = 0x00000030     # display indexes in binary
 
 op_bin = ida_bytes.op_bin
 op_oct = ida_bytes.op_oct
@@ -1790,7 +1791,7 @@ def get_inf_attr(offset):
 
 def set_inf_attr(offset, value):
     if offset == INF_PROCNAME:
-        raise NotImplementedError, "Please use ida_idp.set_processor_type() to change processor"
+        raise NotImplementedError("Please use ida_idp.set_processor_type() to change processor")
     # We really want to go through IDC's equivalent, because it might
     # have side-effects (i.e., send a notification, etc...)
     return eval_idc("set_inf_attr(%d, %d)" % (offset, value))
@@ -2872,26 +2873,26 @@ def get_xref_type():
 
     @return: constants fl_* or dr_*
     """
-    raise DeprecatedIDCError, "use XrefsFrom() XrefsTo() from idautils instead."
+    raise DeprecatedIDCError("use XrefsFrom() XrefsTo() from idautils instead.")
 
 
 #----------------------------------------------------------------------------
 #                            F I L E   I / O
 #----------------------------------------------------------------------------
 def fopen(f, mode):
-    raise DeprecatedIDCError, "fopen() deprecated. Use Python file objects instead."
+    raise DeprecatedIDCError("fopen() deprecated. Use Python file objects instead.")
 
 def fclose(handle):
-    raise DeprecatedIDCError, "fclose() deprecated. Use Python file objects instead."
+    raise DeprecatedIDCError("fclose() deprecated. Use Python file objects instead.")
 
 def filelength(handle):
-    raise DeprecatedIDCError, "filelength() deprecated. Use Python file objects instead."
+    raise DeprecatedIDCError("filelength() deprecated. Use Python file objects instead.")
 
 def fseek(handle, offset, origin):
-    raise DeprecatedIDCError, "fseek() deprecated. Use Python file objects instead."
+    raise DeprecatedIDCError("fseek() deprecated. Use Python file objects instead.")
 
 def ftell(handle):
-    raise DeprecatedIDCError, "ftell() deprecated. Use Python file objects instead."
+    raise DeprecatedIDCError("ftell() deprecated. Use Python file objects instead.")
 
 
 def LoadFile(filepath, pos, ea, size):
@@ -2945,31 +2946,31 @@ def savefile(filepath, pos, ea, size): return SaveFile(filepath, pos, ea, size)
 
 
 def fgetc(handle):
-    raise DeprecatedIDCError, "fgetc() deprecated. Use Python file objects instead."
+    raise DeprecatedIDCError("fgetc() deprecated. Use Python file objects instead.")
 
 def fputc(byte, handle):
-    raise DeprecatedIDCError, "fputc() deprecated. Use Python file objects instead."
+    raise DeprecatedIDCError("fputc() deprecated. Use Python file objects instead.")
 
 def fprintf(handle, format, *args):
-    raise DeprecatedIDCError, "fprintf() deprecated. Use Python file objects instead."
+    raise DeprecatedIDCError("fprintf() deprecated. Use Python file objects instead.")
 
 def readshort(handle, mostfirst):
-    raise DeprecatedIDCError, "readshort() deprecated. Use Python file objects instead."
+    raise DeprecatedIDCError("readshort() deprecated. Use Python file objects instead.")
 
 def readlong(handle, mostfirst):
-    raise DeprecatedIDCError, "readlong() deprecated. Use Python file objects instead."
+    raise DeprecatedIDCError("readlong() deprecated. Use Python file objects instead.")
 
 def writeshort(handle, word, mostfirst):
-    raise DeprecatedIDCError, "writeshort() deprecated. Use Python file objects instead."
+    raise DeprecatedIDCError("writeshort() deprecated. Use Python file objects instead.")
 
 def writelong(handle, dword, mostfirst):
-    raise DeprecatedIDCError, "writelong() deprecated. Use Python file objects instead."
+    raise DeprecatedIDCError("writelong() deprecated. Use Python file objects instead.")
 
 def readstr(handle):
-    raise DeprecatedIDCError, "readstr() deprecated. Use Python file objects instead."
+    raise DeprecatedIDCError("readstr() deprecated. Use Python file objects instead.")
 
 def writestr(handle, s):
-    raise DeprecatedIDCError, "writestr() deprecated. Use Python file objects instead."
+    raise DeprecatedIDCError("writestr() deprecated. Use Python file objects instead.")
 
 # ----------------------------------------------------------------------------
 #                           F U N C T I O N S
@@ -4376,11 +4377,11 @@ def next_func_chunk(funcea, tailea):
            fci.chunk().end_ea > tailea:
             found = True
             break
-        if not fci.next():
+        if not next(fci):
             break
 
     # Return the next chunk, if there is one
-    if found and fci.next():
+    if found and next(fci):
         return fci.chunk().start_ea
     else:
         return BADADDR
@@ -5484,7 +5485,7 @@ def send_dbg_command(cmd):
     """
     s = eval_idc('send_dbg_command("%s");' % ida_kernwin.str2user(cmd))
     if s.startswith("IDC_FAILURE"):
-        raise Exception, "Debugger command is available only when the debugger is active!"
+        raise Exception("Debugger command is available only when the debugger is active!")
     return s
 
 # wfne flag is combination of the following:
@@ -5773,10 +5774,10 @@ def set_reg_value(value, name):
            A register name in the left side of an assignment will do too.
     """
     rv = ida_idd.regval_t()
-    if type(value) == types.StringType:
+    if type(value) == bytes:
         value = int(value, 16)
-    elif type(value) != types.IntType and type(value) != types.LongType:
-        print "set_reg_value: value must be integer!"
+    elif type(value) != int and type(value) != int:
+        print("set_reg_value: value must be integer!")
         return BADADDR
 
     if value < 0:
@@ -6067,7 +6068,7 @@ def get_color(ea, what):
     @return: color code in RGB (hex 0xBBGGRR)
     """
     if what not in [ CIC_ITEM, CIC_FUNC, CIC_SEGM ]:
-        raise ValueError, "'what' must be one of CIC_ITEM, CIC_FUNC and CIC_SEGM"
+        raise ValueError("'what' must be one of CIC_ITEM, CIC_FUNC and CIC_SEGM")
 
     if what == CIC_ITEM:
         return ida_nalt.get_item_color(ea)
@@ -6105,7 +6106,7 @@ def set_color(ea, what, color):
     @return: success (True or False)
     """
     if what not in [ CIC_ITEM, CIC_FUNC, CIC_SEGM ]:
-        raise ValueError, "'what' must be one of CIC_ITEM, CIC_FUNC and CIC_SEGM"
+        raise ValueError("'what' must be one of CIC_ITEM, CIC_FUNC and CIC_SEGM")
 
     if what == CIC_ITEM:
         return ida_nalt.set_item_color(ea, color)

--- a/python/init.py
+++ b/python/init.py
@@ -11,6 +11,7 @@
 # -----------------------------------------------------------------------
 # init.py - Essential init routines
 # -----------------------------------------------------------------------
+from __future__ import print_function
 import os
 import sys
 import time
@@ -22,7 +23,7 @@ lib_dynload = os.path.join(
     IDAPYTHON_DYNLOAD_BASE,
     "python", "lib", "python2.7", "lib-dynload")
 
-is_x64 = sys.maxint >= 0x100000000L
+is_x64 = sys.maxsize >= 0x100000000
 if is_x64:
     # x64 python requires our lib_dynload to be added; sys.path seems
     # to be composed differently than x86 builds.
@@ -42,9 +43,9 @@ try:
     import ida_kernwin
     import ida_diskio
 except ImportError as e:
-    print "Import failed: %s. Current sys.path:" % str(e)
+    print("Import failed: %s. Current sys.path:" % str(e))
     for p in sys.path:
-        print "\t%s" % p
+        print("\t%s" % p)
     raise
 
 

--- a/pywraps/py_bytes_custdata.py
+++ b/pywraps/py_bytes_custdata.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # -----------------------------------------------------------------------
 #<pycode(py_bytes_custdata)>
 DTP_NODUP = 0x0001
@@ -59,14 +60,14 @@ def register_data_types_and_formats(formats):
               return False
         attach_custom_data_format(dtid, dfid)
         if dtid == 0:
-            print "Registered format '%s' with built-in types, ID=%d" % (df.name, dfid)
+            print("Registered format '%s' with built-in types, ID=%d" % (df.name, dfid))
         else:
-            print "   Registered format '%s', ID=%d (dtid=%d)" % (df.name, dfid, dtid)
+            print("   Registered format '%s', ID=%d (dtid=%d)" % (df.name, dfid, dtid))
         return True
 
     def __reg_type(dt):
         register_custom_data_type(dt)
-        print "Registered type '%s', ID=%d" % (dt.name, dt.id)
+        print("Registered type '%s', ID=%d" % (dt.name, dt.id))
         return dt.id != -1
     ok = __walk_types_and_formats(formats, __reg_type, __reg_format, True)
     return 1 if ok else -1
@@ -77,12 +78,12 @@ def unregister_data_types_and_formats(formats):
     unregisters multiple data types and formats at once.
     """
     def __unreg_format(df, dtid):
-        print "%snregistering format '%s'" % ("U" if dtid == 0 else "   u", df.name)
+        print("%snregistering format '%s'" % ("U" if dtid == 0 else "   u", df.name))
         unregister_custom_data_format(df.id)
         return True
 
     def __unreg_type(dt):
-        print "Unregistering type '%s', ID=%d" % (dt.name, dt.id)
+        print("Unregistering type '%s', ID=%d" % (dt.name, dt.id))
         unregister_custom_data_type(dt.id)
         return True
     ok = __walk_types_and_formats(formats, __unreg_type, __unreg_format, False)

--- a/pywraps/py_funcs.py
+++ b/pywraps/py_funcs.py
@@ -4,12 +4,12 @@ import ida_idaapi
 def calc_thunk_func_target(*args):
     if len(args) == 2:
         pfn, rawptr = args
-        target, fptr = calc_thunk_func_target.func_dict["orig"](pfn)
+        target, fptr = calc_thunk_func_target.__dict__["orig"](pfn)
         import ida_pro
         ida_pro.ea_pointer.frompointer(rawptr).assign(fptr)
         return target
     else:
-        return calc_thunk_func_target.func_dict["orig"](*args)
+        return calc_thunk_func_target.__dict__["orig"](*args)
 #</pycode(py_funcs)>
 
 #<pycode_BC695(py_funcs)>

--- a/pywraps/py_gdl.py
+++ b/pywraps/py_gdl.py
@@ -57,7 +57,7 @@ class FlowChart(object):
         @param bounds: A tuple of the form (start, end). Used if "f" is None
         @param flags: one of the FC_xxxx flags. One interesting flag is FC_PREDS
         """
-        if (f is None) and (bounds is None or type(bounds) != types.TupleType):
+        if (f is None) and (bounds is None or type(bounds) != tuple):
             raise Exception("Please specifiy either a function or start/end pair")
 
         if bounds is None:

--- a/pywraps/py_hexrays.py
+++ b/pywraps/py_hexrays.py
@@ -150,7 +150,7 @@ def cblock_iter(self):
     iter = self.begin()
     for i in range(self.size()):
         yield iter.cur
-        iter.next()
+        next(iter)
 
     return
 cblock_t.__iter__ = cblock_iter
@@ -163,7 +163,7 @@ def cblock_find(self, item):
     for i in range(self.size()):
         if iter.cur == item:
             return iter
-        iter.next()
+        next(iter)
 
     return
 cblock_t.find = cblock_find
@@ -175,7 +175,7 @@ def cblock_index(self, item):
     for i in range(self.size()):
         if iter.cur == item:
             return i
-        iter.next()
+        next(iter)
 
     return
 cblock_t.index = cblock_index
@@ -187,7 +187,7 @@ def cblock_at(self, index):
     for i in range(self.size()):
         if i == index:
             return iter.cur
-        iter.next()
+        next(iter)
 
     return
 cblock_t.at = cblock_at
@@ -525,5 +525,5 @@ def remove_hexrays_callback(callback):
 get_tform_vdui=get_widget_vdui
 hx_get_tform_vdui=hx_get_widget_vdui
 HEXRAYS_API_MAGIC1=(HEXRAYS_API_MAGIC>>32)
-HEXRAYS_API_MAGIC2=(HEXRAYS_API_MAGIC&0xFFFFFFFFL)
+HEXRAYS_API_MAGIC2=(HEXRAYS_API_MAGIC&0xFFFFFFFF)
 #</pycode_BC695(py_hexrays)>

--- a/pywraps/py_idaapi.py
+++ b/pywraps/py_idaapi.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # -----------------------------------------------------------------------
 try:
     import pywraps
@@ -12,7 +13,7 @@ import datetime
 
 #<pycode(py_idaapi)>
 
-__EA64__ = BADADDR == 0xFFFFFFFFFFFFFFFFL
+__EA64__ = BADADDR == 0xFFFFFFFFFFFFFFFF
 
 import struct
 import traceback
@@ -67,7 +68,7 @@ def _replace_module_function(replacement):
     orig = getattr(mod, name)
     replacement.__doc__ = orig.__doc__
     replacement.__name__ = name
-    replacement.func_dict["orig"] = orig
+    replacement.__dict__["orig"] = orig
     setattr(mod, name, replacement)
 
 def replfun(func):
@@ -447,7 +448,7 @@ def IDAPython_LoadProcMod(script, g, print_error=True):
     Load processor module.
     """
     script = _utf8_native(script)
-    pname = g['__name__'] if g and g.has_key("__name__") else '__main__'
+    pname = g['__name__'] if g and "__name__" in g else '__main__'
     parent = sys.modules[pname]
 
     scriptpath, scriptname = os.path.split(script)
@@ -488,7 +489,7 @@ def IDAPython_UnLoadProcMod(script, g, print_error=True):
     Unload processor module.
     """
     script = _utf8_native(script)
-    pname = g['__name__'] if g and g.has_key("__name__") else '__main__'
+    pname = g['__name__'] if g and "__name__" in g else '__main__'
     parent = sys.modules[pname]
 
     scriptname = os.path.split(script)[1]
@@ -648,7 +649,7 @@ class __BC695:
         pass
 
     def replace_fun(self, new):
-        new.func_dict["bc695redef"] = True
+        new.__dict__["bc695redef"] = True
         _replace_module_function(new)
 
 _BC695 = __BC695()

--- a/pywraps/py_idd.py
+++ b/pywraps/py_idd.py
@@ -23,8 +23,8 @@ class Appcall_array__(object):
     def pack(self, L):
         """Packs a list or tuple into a byref buffer"""
         t = type(L)
-        if not (t == types.ListType or t == types.TupleType):
-            raise ValueError, "Either a list or a tuple must be passed"
+        if not (t == list or t == tuple):
+            raise ValueError("Either a list or a tuple must be passed")
         self.__size = len(L)
         if self.__size == 1:
             self.__typedobj = Appcall__.typedobj(self.__type + ";")
@@ -52,12 +52,12 @@ class Appcall_array__(object):
             buf = buf.value
 
         # we can only unpack from strings
-        if type(buf) != types.StringType:
-            raise ValueError, "Cannot unpack this type!"
+        if type(buf) != bytes:
+            raise ValueError("Cannot unpack this type!")
         # now unpack
         ok, obj = self.__typedobj.retrieve(buf)
         if not ok:
-            raise ValueError, "Failed while unpacking!"
+            raise ValueError("Failed while unpacking!")
         if not as_list:
             return obj
         return self.try_to_convert_to_list(obj)
@@ -115,7 +115,7 @@ class Appcall_callable__(object):
     def __call__(self, *args):
         """Make object callable. We redirect execution to idaapi.appcall()"""
         if self.ea is None:
-            raise ValueError, "Object not callable!"
+            raise ValueError("Object not callable!")
 
         # convert arguments to a list
         arg_list = list(args)
@@ -141,7 +141,7 @@ class Appcall_callable__(object):
 
         # Return or re-raise exception
         if e_obj:
-            raise Exception, e_obj
+            raise Exception(e_obj)
 
         return r
 
@@ -189,7 +189,7 @@ class Appcall_callable__(object):
         if src is None:
             src = self.ea
 
-        if type(src) == types.StringType:
+        if type(src) == bytes:
             return _ida_typeinf.unpack_object_from_bv(None, self.type, self.fields, src, flags)
         else:
             return _ida_typeinf.unpack_object_from_idb(None, self.type, self.fields, src, flags)
@@ -232,7 +232,7 @@ class Appcall_consts__(object):
     def __getattr__(self, attr):
         v = Appcall__.valueof(attr, self.__default)
         if v is None:
-            raise ValueError, "No constant with name " + attr
+            raise ValueError("No constant with name " + attr)
         return v
 
 # -----------------------------------------------------------------------
@@ -281,13 +281,13 @@ class Appcall__(object):
         """
 
         # a string? try to resolve it
-        if type(name_or_ea) == types.StringType:
+        if type(name_or_ea) == bytes:
             ea = _ida_name.get_name_ea(_ida_idaapi.BADADDR, name_or_ea)
         else:
             ea = name_or_ea
         # could not resolve name or invalid address?
         if ea == _ida_idaapi.BADADDR or not _ida_bytes.is_mapped(ea):
-            raise ValueError, "Undefined function " + name_or_ea
+            raise ValueError("Undefined function " + name_or_ea)
         return ea
 
     @staticmethod
@@ -310,7 +310,7 @@ class Appcall__(object):
 
         result = _ida_typeinf.idc_parse_decl(None, prototype, flags)
         if result is None:
-            raise ValueError, "Could not parse type: " + prototype
+            raise ValueError("Could not parse type: " + prototype)
 
         # Return the callable method with type info
         return Appcall_callable__(ea, result[1], result[2])
@@ -320,7 +320,7 @@ class Appcall__(object):
         # resolve and raise exception on error
         ea = self.__name_or_ea(name_or_ea)
         if ea == _ida_idaapi.BADADDR:
-            raise ValueError, "Undefined function " + name
+            raise ValueError("Undefined function " + name)
         # Return the callable method
         return Appcall_callable__(ea)
 
@@ -400,7 +400,7 @@ class Appcall__(object):
         # parse the type
         result = _ida_typeinf.idc_parse_decl(None, typestr, 1 | 2 | 4) # PT_SIL | PT_NDC | PT_TYP
         if result is None:
-            raise ValueError, "Could not parse type: " + typestr
+            raise ValueError("Could not parse type: " + typestr)
         # Return the callable method with type info
         return Appcall_callable__(ea, result[1], result[2])
 

--- a/pywraps/py_kernwin_askform.py
+++ b/pywraps/py_kernwin_askform.py
@@ -1112,7 +1112,7 @@ class Form(object):
                 # Push argument(s)
                 # (Some controls need more than one argument)
                 arg = ctrl.get_arg()
-                if isinstance(arg, (types.ListType, types.TupleType)):
+                if isinstance(arg, (list, tuple)):
                     # Push all args
                     args.extend(arg)
                 else:
@@ -1337,14 +1337,14 @@ class Form(object):
         elif isinstance(ctrl, Form.InputControl):
             return (1, ctrl.size)
         else:
-            raise NotImplementedError, "Not yet implemented"
+            raise NotImplementedError("Not yet implemented")
 
 # --------------------------------------------------------------------------
 # Instantiate ask_form function pointer
 try:
     import ctypes
     # Setup the numeric argument size
-    Form.NumericArgument.DefI64 = _ida_idaapi.BADADDR == 0xFFFFFFFFFFFFFFFFL
+    Form.NumericArgument.DefI64 = _ida_idaapi.BADADDR == 0xFFFFFFFFFFFFFFFF
     __ask_form_callable = ctypes.CFUNCTYPE(ctypes.c_long)(_ida_kernwin.py_get_ask_form())
     __open_form_callable = ctypes.CFUNCTYPE(ctypes.c_long)(_ida_kernwin.py_get_open_form())
 except:

--- a/pywraps/py_kernwin_plgform.py
+++ b/pywraps/py_kernwin_plgform.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #<pycode(py_kernwin_plgform)>
 import sys
 class PluginForm(object):
@@ -51,7 +52,7 @@ class PluginForm(object):
     def _ensure_widget_deps(ctx):
         for key, modname in [("sip", "sip"), ("QtWidgets", "PyQt5.QtWidgets")]:
             if not hasattr(ctx, key):
-                print "Note: importing '%s' module into %s" % (key, ctx)
+                print("Note: importing '%s' module into %s" % (key, ctx))
                 import importlib
                 setattr(ctx, key, importlib.import_module(modname))
 

--- a/pywraps/py_lines.py
+++ b/pywraps/py_lines.py
@@ -2,7 +2,7 @@
 import _ida_idaapi
 
 # ---------------- Color escape sequence defitions -------------------------
-COLOR_ADDR_SIZE = 16 if _ida_idaapi.BADADDR == 0xFFFFFFFFFFFFFFFFL else 8
+COLOR_ADDR_SIZE = 16 if _ida_idaapi.BADADDR == 0xFFFFFFFFFFFFFFFF else 8
 SCOLOR_FG_MAX   = '\x28'             #  Max color number
 SCOLOR_OPND1    = chr(cvar.COLOR_ADDR+1)  #  Instruction operand 1
 SCOLOR_OPND2    = chr(cvar.COLOR_ADDR+2)  #  Instruction operand 2

--- a/pywraps/py_name.py
+++ b/pywraps/py_name.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 #<pycode(py_name)>
 import _ida_idaapi

--- a/tools/chkapi.py
+++ b/tools/chkapi.py
@@ -1,4 +1,5 @@
 from __future__ import with_statement
+from __future__ import print_function
 
 import sys, optparse, re, pprint
 

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -3,6 +3,7 @@ Deploy code snips into swig interface files
 
 (c) Hex-Rays
 """
+from __future__ import print_function
 
 import sys, re, os, glob
 
@@ -11,7 +12,7 @@ major, minor, micro, _, _ = sys.version_info
 try:
     from argparse import ArgumentParser
 except:
-    print "Failed to import module 'argparse'. Upgrade to Python 2.7, copy argparse.py to this directory or try 'apt-get install python-argparse'"
+    print("Failed to import module 'argparse'. Upgrade to Python 2.7, copy argparse.py to this directory or try 'apt-get install python-argparse'")
     raise
 
 parser = ArgumentParser()

--- a/tools/docs/hrdoc.py
+++ b/tools/docs/hrdoc.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import sys
 import shutil
@@ -98,14 +99,14 @@ def patch_docs():
             lines = r
         r = add_footer(lines)
         if not r:
-            print "-",
+            print("-", end=' ')
             continue
 
         with open(fn, 'w') as f:
             f.write(r)
-        print "+",
+        print("+", end=' ')
 
-    print "\nDocumentation patched!"
+    print("\nDocumentation patched!")
 
 # --------------------------------------------------------------------------
 def main():
@@ -118,11 +119,11 @@ def main():
     old_dir = os.getcwd()
 
     try:
-        print "Generating documentation....."
+        print("Generating documentation.....")
         import ida_pro
         try:
             ida_pro._BC695
-            print "'ida_pro._BC695' exists. Please recompile with BC695=0 (see makefile). Bailing out."
+            print("'ida_pro._BC695' exists. Please recompile with BC695=0 (see makefile). Bailing out.")
             return -1
         except:
             pass # ok
@@ -133,7 +134,7 @@ def main():
         os.chdir(DOC_DIR)
         patch_docs()
 
-        print "Documentation generated!"
+        print("Documentation generated!")
 
     finally:
         os.chdir(old_dir)

--- a/tools/doxygen_utils.py
+++ b/tools/doxygen_utils.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 import os
 import xml.etree.ElementTree as ET

--- a/tools/funlines.py
+++ b/tools/funlines.py
@@ -1,10 +1,11 @@
+from __future__ import print_function
 
 import os, sys, pickle, subprocess
 
 try:
   from argparse import ArgumentParser
 except:
-  print "Failed to import module 'argparse'. Upgrade to Python 2.7, copy argparse.py to this directory or try 'apt-get install python-argparse'"
+  print("Failed to import module 'argparse'. Upgrade to Python 2.7, copy argparse.py to this directory or try 'apt-get install python-argparse'")
   raise
 
 parser = ArgumentParser()
@@ -21,11 +22,11 @@ sk_orig = sorted(orig.keys())
 sk_then = sorted(then.keys())
 for key in sk_orig:
     if not key in sk_then:
-        print "Missing expected key: %s" % key
+        print("Missing expected key: %s" % key)
 
 for key in sk_then:
     if not key in sk_orig:
-        print "Unexpected key found: %s" % key
+        print("Unexpected key found: %s" % key)
 
 subprocess.check_call(["rm", "-r", "-f", "/tmp/diffs"])
 subprocess.check_call(["mkdir", "/tmp/diffs"])

--- a/tools/genhooks/genhooks.py
+++ b/tools/genhooks/genhooks.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # TODO:
 # * auto_queue_empty must return 1 by default. How should
 #   that be specified? In idp.hpp, or in a specific, 'recipe' file?
@@ -30,7 +31,7 @@ p.add_argument("-s", "--strip-prefix",  required=False, dest="strip_prefix",  he
 args = p.parse_args()
 
 def warn(msg):
-    print "#### WARNING: %s" % msg
+    print("#### WARNING: %s" % msg)
 
 if args.recipe:
     execfile(args.recipe)
@@ -160,12 +161,12 @@ for enumval_el in enum_el.findall("./enumvalue"):
 
 def dump():
     for enumerator in enumerators:
-        print "%s:" % enumerator["name"]
+        print("%s:" % enumerator["name"])
         rdata = enumerator["params"][0]
-        print "\t%s: %s (default=%s)" % (
-            rdata["name"], rdata["type"], rdata["default"])
+        print("\t%s: %s (default=%s)" % (
+            rdata["name"], rdata["type"], rdata["default"]))
         for p in enumerator["params"][1:]:
-            print "\t%s: %s" % (p["name"], p["type"])
+            print("\t%s: %s" % (p["name"], p["type"]))
 
 #dump()
 

--- a/tools/genidaapi.py
+++ b/tools/genidaapi.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 import sys
 import string
@@ -5,7 +6,7 @@ import string
 try:
     from argparse import ArgumentParser
 except:
-    print "Failed to import module 'argparse'. Upgrade to Python 2.7, copy argparse.py to this directory or try 'apt-get install python-argparse'"
+    print("Failed to import module 'argparse'. Upgrade to Python 2.7, copy argparse.py to this directory or try 'apt-get install python-argparse'")
     raise
 
 parser = ArgumentParser()

--- a/tools/genswigheader.py
+++ b/tools/genswigheader.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 import sys
 import os
@@ -6,7 +7,7 @@ import glob
 try:
     from argparse import ArgumentParser
 except:
-    print "Failed to import module 'argparse'. Upgrade to Python 2.7, copy argparse.py to this directory or try 'apt-get install python-argparse'"
+    print("Failed to import module 'argparse'. Upgrade to Python 2.7, copy argparse.py to this directory or try 'apt-get install python-argparse'")
     raise
 
 parser = ArgumentParser()

--- a/tools/inject_plfm.py
+++ b/tools/inject_plfm.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 import re
 import string
@@ -5,7 +6,7 @@ import string
 try:
     from argparse import ArgumentParser
 except:
-    print "Failed to import module 'argparse'. Upgrade to Python 2.7, copy argparse.py to this directory or try 'apt-get install python-argparse'"
+    print("Failed to import module 'argparse'. Upgrade to Python 2.7, copy argparse.py to this directory or try 'apt-get install python-argparse'")
     raise
 
 parser = ArgumentParser()

--- a/tools/inject_pydoc.py
+++ b/tools/inject_pydoc.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #
 # This (non-idiomatic) python script is in charge of
 #   1) Parsing all .i files in the 'swig/' directory, and
@@ -19,7 +20,7 @@ import xml.etree.ElementTree as ET
 try:
     from argparse import ArgumentParser
 except:
-    print "Failed to import module 'argparse'. Upgrade to Python 2.7, copy argparse.py to this directory or try 'apt-get install python-argparse'"
+    print("Failed to import module 'argparse'. Upgrade to Python 2.7, copy argparse.py to this directory or try 'apt-get install python-argparse'")
     raise
 
 parser = ArgumentParser()
@@ -40,7 +41,7 @@ DOCSTR_MARKER  = '"""'
 
 def verb(msg):
     if args.verbose:
-        print msg
+        print(msg)
 
 # --------------------------------------------------------------------------
 def load_patches(args):
@@ -148,7 +149,7 @@ class collect_pydoc_t(object):
     def collect_fun(self, fun_name):
         collected = []
         while len(self.lines) > 0:
-            line = self.next()
+            line = next(self)
             if self.state is self.S_IN_PYDOC:
                 if line.startswith(self.PYDOC_END):
                     self.state = self.S_UNKNOWN
@@ -172,7 +173,7 @@ class collect_pydoc_t(object):
     def collect_method(self, cls, method_name):
         collected = []
         while len(self.lines) > 0:
-            line = self.next()
+            line = next(self)
             if self.state is self.S_IN_PYDOC:
                 if line.startswith(self.PYDOC_END):
                     self.state = self.S_UNKNOWN
@@ -194,7 +195,7 @@ class collect_pydoc_t(object):
         collected = []
         cls = {"methods":{},"doc":None}
         while len(self.lines) > 0:
-            line = self.next()
+            line = next(self)
             if self.state is self.S_IN_PYDOC:
                 if line.startswith("    def "):
                     self.collect_method(cls, get_fun_name(line))
@@ -220,7 +221,7 @@ class collect_pydoc_t(object):
         context = None
         doc = []
         while len(self.lines) > 0:
-            line = self.next()
+            line = next(self)
             if self.state is self.S_UNKNOWN:
                 if line.startswith(self.PYDOC_START):
                     self.state = self.S_IN_PYDOC
@@ -409,7 +410,7 @@ class idaapi_fixer_t(object):
         return line
 
     def copy(self, out):
-        line = self.next()
+        line = next(self)
         out.append(line)
         return line
 
@@ -484,7 +485,7 @@ class idaapi_fixer_t(object):
             # Opening docstring line; determine indentation level
             indent = get_indent_string(line)
             while True:
-                line = self.next()
+                line = next(self)
                 if line.find(DOCSTR_MARKER) > -1:
                     # Closing docstring line
                     swig_generated_param_names = self.extract_swig_generated_param_names(fun_name, out[doc_start_line_idx:])
@@ -537,7 +538,7 @@ class idaapi_fixer_t(object):
         # If class has doc, maybe inject additional <pydoc>
         if line.find(DOCSTR_MARKER) > -1:
             while True:
-                line = self.next()
+                line = next(self)
                 if line.find(DOCSTR_MARKER) > -1:
                     doc = found["doc"]
                     if doc is not None:
@@ -553,7 +554,7 @@ class idaapi_fixer_t(object):
         # their docstring
         method_start = indent + "def "
         while True:
-            line = self.next()
+            line = next(self)
             # print "Fixing methods.. Line is '%s'" % line
             if line.startswith(indent) or line.strip() == "":
                 if line.startswith(method_start):
@@ -568,7 +569,7 @@ class idaapi_fixer_t(object):
     def fix_assignment(self, out, match):
         # out.append("LOL: %s" % match.group(1))
         line = self.copy(out)
-        line = self.next()
+        line = next(self)
         if not line.startswith(DOCSTR_MARKER):
             # apparently no epydoc-compliant docstring follows. Let's
             # look for a possible match in the xml doc.
@@ -591,7 +592,7 @@ class idaapi_fixer_t(object):
         self.xml_tree = doxygen_utils.load_xml_for_module(xml_dir_path, args.module)
         out = []
         while len(self.lines) > 0:
-            line = self.next()
+            line = next(self)
             if line.startswith("def "):
                 self.push_front(line)
                 self.fix_fun(out)

--- a/tools/patch_codegen.py
+++ b/tools/patch_codegen.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 import os
 import re
@@ -7,7 +8,7 @@ import xml.etree.ElementTree as ET
 try:
     from argparse import ArgumentParser
 except:
-    print "Failed to import module 'argparse'. Upgrade to Python 2.7, copy argparse.py to this directory or try 'apt-get install python-argparse'"
+    print("Failed to import module 'argparse'. Upgrade to Python 2.7, copy argparse.py to this directory or try 'apt-get install python-argparse'")
     raise
 
 parser = ArgumentParser(description='Patch some code generation, so it builds')

--- a/tools/patch_constants.py
+++ b/tools/patch_constants.py
@@ -1,10 +1,11 @@
+from __future__ import print_function
 
 import re
 
 try:
   from argparse import ArgumentParser
 except:
-  print "Failed to import module 'argparse'. Upgrade to Python 2.7, copy argparse.py to this directory or try 'apt-get install python-argparse'"
+  print("Failed to import module 'argparse'. Upgrade to Python 2.7, copy argparse.py to this directory or try 'apt-get install python-argparse'")
   raise
 
 parser = ArgumentParser(description='Patch calling conventions for some functions, so it builds on windows')
@@ -171,13 +172,13 @@ with open(args.file, "rb") as f:
             if almost_there_re.match(line):
                 status = STAT_ALMOST_THERE
                 if args.verbose:
-                    print "Almost there at line: '%s'" % line
+                    print("Almost there at line: '%s'" % line)
             outlines.append(line)
         elif status == STAT_ALMOST_THERE:
             if start_collecting_re.match(line):
                 status = STAT_COLLECTING
                 if args.verbose:
-                    print "Starting to collect at line: '%s'" % line
+                    print("Starting to collect at line: '%s'" % line)
                 outlines.append("#ifdef __NT__\n")
                 outlines.append("#pragma warning(disable: 4883)\n")
                 outlines.append("#endif // __NT__\n")
@@ -191,14 +192,14 @@ with open(args.file, "rb") as f:
 
                 status = STAT_SEEKING
                 if args.verbose:
-                    print "Done collecting at line: '%s'" % line
+                    print("Done collecting at line: '%s'" % line)
             else:
                 match = set_constant_re.search(line)
                 if match:
                     tpl = (match.group(1), match.group(2))
                     constants.append(tpl)
                     if args.verbose:
-                        print "Found 'SetConstant' expression: %s => %s" % tpl
+                        print("Found 'SetConstant' expression: %s => %s" % tpl)
                 else:
                     outlines.append(line)
 

--- a/tools/patch_directors_cc.py
+++ b/tools/patch_directors_cc.py
@@ -1,8 +1,9 @@
+from __future__ import print_function
 
 try:
   from argparse import ArgumentParser
 except:
-  print "Failed to import module 'argparse'. Upgrade to Python 2.7, copy argparse.py to this directory or try 'apt-get install python-argparse'"
+  print("Failed to import module 'argparse'. Upgrade to Python 2.7, copy argparse.py to this directory or try 'apt-get install python-argparse'")
   raise
 
 parser = ArgumentParser(description='Patch calling conventions for some functions, so it builds on windows')


### PR DESCRIPTION
This PR seeks to make the code _syntax compatible_ with both Python 2 and Python 3.  It was achieved by doing [__futurize --stage1 -w .__](http://python-future.org/futurize_cheatsheet.html)