### PR TITLE
Add continuous integration testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: cpp
+compiler:
+  - clang
+addons:
+  apt:
+    packages:
+    - python-pip
+matrix:
+  include:
+    - os: linux
+      env: __LINUX__=1
+    # - os: osx  # TODO: add macOS after Linux is working
+    #   env: __MAC__=1
+script:
+  - make
+  - python2 build.py


### PR DESCRIPTION
This PR recommends adding Travis CI [or a similar continuous integration tool](https://github.com/marketplace/category/continuous-integration) to automatically run __make ; python2 build.py__ on every pull request or code change.  Such automated testing should help to optimize the adding of code changes.  To enable this testing, the repo would need to be enabled at https://travis-ci.com/idapython/src/new/master  This service is free to open source projects.