### PR TITLE
Simplifies _print_hex method

### DIFF
--- a/pywraps/py_idaapi.py
+++ b/pywraps/py_idaapi.py
@@ -694,8 +694,7 @@ class IDAPython_displayhook:
             storage.append(str(item))
 
     def _print_hex(self, x):
-        s = hex(x)
-        return s[0:-1] if s.endswith("L") else s
+        return hex(x).rstrip('L')
 
     def displayhook(self, item):
         if item is None or type(item) is bool:

--- a/pywraps/py_idaapi.py
+++ b/pywraps/py_idaapi.py
@@ -694,7 +694,7 @@ class IDAPython_displayhook:
             storage.append(str(item))
 
     def _print_hex(self, x):
-        return hex(x).rstrip('L')
+        return hex(x)
 
     def displayhook(self, item):
         if item is None or type(item) is bool:


### PR DESCRIPTION
Simplifies the `_print_hex` method.

Note that there are ~4 different ways of implementing it:
```
In [1]: def a(x):
   ...:     return hex(x).rstrip('L')
   ...: def b(x):
   ...:     s = hex(x)
   ...:     return s[0:-1] if s.endswith("L") else s
   ...: def c(x):
   ...:     return '0x%x' % x
   ...: def d(x):
   ...:     return '0x{:x}'.format(x)
```

Also, a microbenchmark, which is probably not so relevant and also not so great due to caching, attached below. However, if we take into account how much longer the slowest run took then the average one, it might be somehow helpful...

![image](https://user-images.githubusercontent.com/10009354/61495318-f8843000-a9b8-11e9-9caf-30bee047407e.png)

Interestingly, on Python 3, there might be no cache for those:
![image](https://user-images.githubusercontent.com/10009354/61495413-3f722580-a9b9-11e9-9418-09f450195329.png)

PS: On Python 3 this could be monkey patched with just `hex` function.

Just in case, the full test code below (note that you can paste it into IPython in the exact form I paste here):
```
In [1]: def a(x):
   ...:     return hex(x).rstrip('L')
   ...: def b(x):
   ...:     s = hex(x)
   ...:     return s[0:-1] if s.endswith("L") else s
   ...: def c(x):
   ...:     return '0x%x' % x
   ...: def d(x):
   ...:     return '0x{:x}'.format(x)
   ...:
   ...: print([f(2**64) for f in [hex, a, b, c, d]])
   ...: %timeit a(1337)
   ...: %timeit b(1337)
   ...: %timeit c(1337)
   ...: %timeit d(1337)
   ...: v = 2**64
   ...: %timeit a(v)
   ...: %timeit b(v)
   ...: %timeit c(v)
   ...: %timeit d(v)
```