### PR TITLE
Don't replace __file__ with an empty string on built-in modules

### DIFF
--- a/pywraps/py_idaapi.py
+++ b/pywraps/py_idaapi.py
@@ -453,7 +453,7 @@ def IDAPython_ExecScript(script, g, print_error=True):
     sys.argv = [ script ]
 
     # Adjust the __file__ path in the globals we pass to the script
-    old__file__ = g['__file__'] if '__file__' in g else ''
+    old__file__ = getattr(g, '__file__', None)
     g['__file__'] = script
 
     try:


### PR DESCRIPTION
Python (and the `inspect` module in particular) expects `__file__` to be `None` (or
absent) when a module is built-in and has no source or bytecode file.

See eset/ipyida#25