### PR TITLE
created stubs for missing idc defs referenced in bc695

### DIFF
--- a/python/idc.py
+++ b/python/idc.py
@@ -5908,6 +5908,22 @@ def set_color(ea, what, color):
         else:
             return False
 
+#----------------------------------------------------------------------------
+#                       M I S S I N G   I N   A C T I O N
+#----------------------------------------------------------------------------
+def exec_idc(input): raise DeprecatedIDCError("exec_idc() deprecated.")
+def test_checkpoint(num): raise DeprecatedIDCError("test_checkpoint() deprecated.")
+def get_vxd_func_name(vxdnum, fnnum): raise DeprecatedIDCError("get_vxd_func_name() deprecated.")
+def get_fpnum(ea, n): raise DeprecatedIDCError("get_fpnum() deprecated.")
+def get_exception_code(idx): raise DeprecatedIDCError("get_exception_code() deprecated.")
+def get_exception_name(code): raise DeprecatedIDCError("get_exception_name() deprecated.")
+def get_exception_flags(code): raise DeprecatedIDCError("get_exception_flags() deprecated.")
+def set_exception_flags(code, flags): raise DeprecatedIDCError("set_exception_flags() deprecated.")
+def forget_exception(code): raise DeprecatedIDCError("forget_exception() deprecated.")
+def value_is_object(var): raise DeprecatedIDCError("value_is_object() deprecated.")
+def format_cdata(outvec, value, type, options, info): raise DeprecatedIDCError("format_cdata() deprecated.")
+def set_current_tev(event): raise DeprecatedIDCError("set_current_tev() deprecated.")
+def exec_python(stmt): raise DeprecatedIDCError("exec_python() deprecated.")
 
 #----------------------------------------------------------------------------
 #                       A R M   S P E C I F I C


### PR DESCRIPTION

A number of (assumedly idc) functions in the bc695 compatibility shim are not extant in idc or any other module.  Since I cannot submit a PR to have them removed from the *autogenerated* idc_bc695.py, I am forced to address the issue by adding them to idc.py and having them `raise` `DeprecatedIDCError`.

From idc_bc695.py (py2 & 3 version, ida 7.5):
```
def ExecIDC(input): return exec_idc(input)
def Checkpoint(num): return test_checkpoint(num)
def GetVxdFuncName(vxdnum, fnnum): return get_vxd_func_name(vxdnum, fnnum)
def GetFpNum(ea, n): return get_fpnum(ea, n)
def GetExceptionCode(idx): return get_exception_code(idx)
def GetExceptionName(code): return get_exception_name(code)
def GetExceptionFlags(code): return get_exception_flags(code)
def SetExceptionFlags(code, flags): return set_exception_flags(code, flags)
def ForgetException(code): return forget_exception(code)
def IsObject(var): return value_is_object(var)
def FormatCData(outvec, value, type, options, info): return format_cdata(outvec, value, type, options, info)
def SetCurrentTev(event): return set_current_tev(event)
def RunPythonStatement(stmt): return exec_python(stmt)
```