### PR TITLE
Added the 'encoded' member to the IDAPythonStdOut class

### DIFF
--- a/python/init.py
+++ b/python/init.py
@@ -57,6 +57,10 @@ class IDAPythonStdOut:
     """
     Dummy file-like class that receives stout and stderr
     """
+    def __init__(self):
+        self.encoding = None
+
+
     def write(self, text):
         # NB: in case 'text' is Unicode, msg() will decode it
         # and call msg() to print it


### PR DESCRIPTION
Some object's __str__ method looks for sys.stdout's 'encoded' field to decide how to represent itself as a string.
For example, before, one could not print a z3 expression in IDA.