### PR TITLE
Add check for None in vds_xrefs.py script

### DIFF
--- a/examples/hexrays/vds_xrefs.py
+++ b/examples/hexrays/vds_xrefs.py
@@ -151,7 +151,9 @@ class XrefsForm(ida_kernwin.PluginForm):
         for ea in frm:
             try:
                 cfunc = ida_hexrays.decompile(ea)
-
+                if cfunc is None:
+                    print('decompilation failed for ea:', ea)
+                    continue
                 self.functions.append(cfunc.entry_ea)
                 self.items.append((ea, ida_funcs.get_func_name(cfunc.entry_ea) or "", self.get_decompiled_line(cfunc, ea)))
 


### PR DESCRIPTION
In IDA 7.6 this script failed for a 32bit binary in some cases, so I added a check for None which solved my problem.

I would recommend making this a built-in plugin, I personally know a lot of people (>15) that wanted this feature that didn't know this script existed in the examples directory as a script 