### PR TITLE
Show the chooser when the script is launched

### DIFF
--- a/examples/widgets/tabular_views/custom/chooser_with_folders.py
+++ b/examples/widgets/tabular_views/custom/chooser_with_folders.py
@@ -270,3 +270,8 @@ class idapython_tree_view_t(base_idapython_tree_view_t):
                 self.netnode.supset(idx, repl, SUPVAL_COL0_DATA_TAG)
         self._dump_items()
         return [ida_kernwin.Choose.ALL_CHANGED] + sel
+
+# -----------------------------------------------------------------------
+if __name__ == '__main__':
+    form = idapython_tree_view_t("idapython_tree_view_t test", 100)
+    form.Show()


### PR DESCRIPTION
It is a bit confusing for beginners when they run the script and nothing happens. Now, when the script is launched, it shows the chooser