### PR TITLE
Fix `load_and_run_plugin` paragraph in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,14 @@ It is possible to use the `idc.eval_idc()` to evaluate IDC expressions from Pyth
 
 ### Switching the default language between Python and IDC
 
-By default, IDA will use Python to evaluate expressions. It is possible to change the default language to IDC.
+By default, IDA will use IDC to evaluate expressions in dialog boxes and in `eval_expr()`.  
+It is possible to change the default language to Python.
 
-In order to do that, use the following Python code:
-```c
-load_and_run_plugin("idapython", 4)
-```
-To go back to Python, use the following IDC code:
+In order to do that, use the following (IDC/Python) code:
 ```c
 load_and_run_plugin("idapython", 3)
+```
+To go back to IDC, use the following code:
+```c
+load_and_run_plugin("idapython", 4)
 ```


### PR DESCRIPTION
PR #37 introduced a mistake in the `load_and_run_plugin` paragraph, stating that the default language for evaluating expressions is Python (instead of IDC), as alerted by @0xeb.

To fix this I've decided to find out what `load_and_run_plugin("idapython", <3_or_4>)` actually means.

As the magic numbers {3, 4} aren't documented (AFAIK), I searched for their meaning in the IDAPython DLL.
I've found that the plugin's `run` function calls the SDK function `select_extlang` with either IDC or IDAPython as arguments (depending on whether `run`'s argument is 4 or 3, respectively).

The chosen external language is then used to evaluate expressions in dialog boxes, and also in the `eval_expr()` function.
I've added this fact to the README in order to avoid further confusion.