### PR TITLE
+ added default run/term for modern plugins

### DIFF
--- a/pywraps/py_idaapi.py
+++ b/pywraps/py_idaapi.py
@@ -231,7 +231,8 @@ def _bounded_getitem_iterator(self):
 # -----------------------------------------------------------------------
 class plugin_t(pyidc_opaque_object_t):
     """Base class for all scripted plugins."""
-    pass
+    def run(self, arg): pass
+    def term(self): pass
 
 # -----------------------------------------------------------------------
 class plugmod_t(pyidc_opaque_object_t):


### PR DESCRIPTION
No longer need to implement dummy/empty run/term callbacks in plugin_t.


Reasoning:

Looking at ida_idaapi.py:

```python
# -----------------------------------------------------------------------
class plugmod_t(pyidc_opaque_object_t):
    r"""
    Base class for all scripted multi-plugins.
    """
    pass
```


That was designed a long time ago before `plugmod_t`.

Now look at the current hello world plugin in Python:

```python
import idaapi

class hello_plugmod_t(idaapi.plugmod_t):
    def run(self, arg):
        print("Hello world! (py)")
        return 0

class hello_plugin_t(idaapi.plugin_t):
    flags = idaapi.PLUGIN_UNL | idaapi.PLUGIN_MULTI
    comment = "This is a comment"
    help = "This is help"
    wanted_name = "Hello Python plugin"
    wanted_hotkey = "Alt-F8"

    def init(self):
        return hello_plugmod_t()

    def run(self, arg): pass
    def term(self): pass

def PLUGIN_ENTRY():
    return hello_plugin_t()
```

It does not look nice, because I still have to define both ‘run’ and ‘term’ for plugin_t.

That’s no longer valid these days, since in a regular C plugin, we can leave those callbacks empty.

I added default run/term, since now they are optional (but users can still override for legacy style plugins).

The new SDK’s pyhello should now be simplified to:

```python
import idaapi

class hello_plugmod_t(idaapi.plugmod_t):
    def run(self, arg):
        print("Hello world! (py)")
        return 0

class hello_plugin_t(idaapi.plugin_t):
    flags = idaapi.PLUGIN_UNL | idaapi.PLUGIN_MULTI
    comment = "This is a comment"
    help = "This is help"
    wanted_name = "Hello Python plugin"
    wanted_hotkey = "Alt-F8"

    def init(self):
        return hello_plugmod_t()

def PLUGIN_ENTRY():
    return hello_plugin_t()
```

To even conform with modern plugins ala C++, they don’t need to define a ‘term’ in ‘hello_plugin_t’, instead, they should implement a destructor in ‘hello_plugmod_t’  --> `__del__(self):` , etc..



